### PR TITLE
fix: revise plan profile content — clean up staging issues

### DIFF
--- a/content/posts/amazon-401k-qdro-guide.md
+++ b/content/posts/amazon-401k-qdro-guide.md
@@ -5,29 +5,67 @@ author: "William Peacock"
 description: "Learn how the Amazon 401(k) Plan may be divided in divorce, QDRO requirements, common drafting mistakes, and steps to verify with the plan administrator."
 category: "QDRO"
 tags: ["QDRO", "amazon", "401k", "divorce", "retirement"]
+schema_jsonld: |
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "How to Divide the Amazon 401(k) Plan in Divorce — A QDRO Guide",
+    "datePublished": "2026-04-01",
+    "dateModified": "2026-04-01",
+    "author": {
+      "@type": "Person",
+      "name": "William Peacock",
+      "url": "https://www.linkedin.com/in/williampeacock"
+    }
+  }
+faq_schema_jsonld: |
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Can the Amazon 401(k) Plan be divided in divorce?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes. The marital portion of the Amazon 401(k) Plan may be divided in divorce through a Qualified Domestic Relations Order, depending on state law and the terms of the divorce judgment or settlement."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Do you need a QDRO for the Amazon 401(k) Plan?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes. Because the Amazon 401(k) Plan is an ERISA-qualified retirement plan, division in divorce typically requires a Qualified Domestic Relations Order approved by the plan administrator."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What should a QDRO say about gains and losses?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "The QDRO should specify the valuation date and whether the alternate payee's share includes investment gains or losses between that date and the date the plan processes the order."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How do plan loans affect division of an Amazon 401(k)?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "An outstanding participant loan can reduce the divisible balance or otherwise affect the award, so the QDRO and settlement terms should address how the loan is treated."
+        }
+      }
+    ]
+  }
 ---
 
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "Article",
-  "headline": "How to Divide the Amazon 401(k) Plan in Divorce — A QDRO Guide",
-  "datePublished": "2026-04-01",
-  "dateModified": "2026-04-01",
-  "author": {
-    "@type": "Person",
-    "name": "William Peacock"
-  }
-}
-</script>
-
-# How to Divide the Amazon 401(K) Plan in Divorce — A QDRO Guide
+# How to Divide the Amazon 401(k) Plan in Divorce — A QDRO Guide
 
 > **Disclaimer:** This page provides general information to help you understand how the Amazon 401(K) Plan is handled in divorce. It does not constitute legal advice, and it does not promise any particular outcome.
 
 ---
 
-## About the Amazon 401(K) Plan
+## About the Amazon 401(k) Plan
 
 The Amazon 401(K) Plan is a defined contribution retirement plan offered to eligible employees of Amazon.com Services, LLC and affiliated employers. According to the most recent Form 5500 filing available through the Department of Labor, the plan reported approximately **1,207,759 active participants** at the end of the most recent plan year.
 
@@ -42,7 +80,7 @@ The Amazon 401(K) Plan is a defined contribution retirement plan offered to elig
 
 Amazon is headquartered in Seattle, Washington, but it operates nationwide. Many Amazon employees work in fulfillment centers, corporate offices, and remote positions across multiple jurisdictions. The plan is a pooled retirement plan that covers a large, diverse workforce.
 
-### What the Amazon 401(K) Plan Covers
+### What the Amazon 401(k) Plan Covers
 
 The plan allows eligible employees to contribute:
 
@@ -60,7 +98,7 @@ Both the employee's contributions and any employer match are subject to division
 
 The portion of the Amazon 401(K) Plan that accrued **during the marriage** may be subject to division in divorce.
 
-This depends heavily on state law and the specific plan terms. The actual division of a 401(k) in divorce is done through a Qualified Domestic Relations Order (QDRO), which specifies the amount or percentage awarded to the alternate payee — not a coverture formula or any specific calculation method. The coverture fraction may be used in some states as part of the property division analysis, but the QDRO itself simply states what the alternate payee gets (and when), without prescribing how that number was calculated.
+This depends heavily on state law and the specific plan terms. The actual division of a 401(k) in divorce is done through a Qualified Domestic Relations Order (QDRO), which specifies the amount or percentage awarded to the alternate payee. The QDRO itself simply states what the alternate payee gets, without prescribing how that number was calculated.
 
 **Separate property tracing:** Depending on state law, premarital contributions and their growth may be separate property. Post-marital contributions are typically marital. State law varies significantly on how growth attributable to separate property during marriage is treated.
 
@@ -70,13 +108,13 @@ A 401(k) is a qualified retirement plan under ERISA. This means it **must** be d
 
 ---
 
-## QDRO Requirements for the Amazon 401(K) Plan
+## QDRO Requirements for the Amazon 401(k) Plan
 
 ### Plan Administrator Contact
 
 When preparing a QDRO for the Amazon 401(K) Plan, the plan administrator to contact is:
 
-- **401(K) Committee, c/o Amazon.com Services, LLC, Seattle, WA**
+- **401(K) Committee**, c/o Amazon.com Services, LLC, Seattle, WA
 
 Always verify the current administrator address and required QDRO procedures directly with Amazon's HR or benefits department. Plan procedures can change, and outdated information can lead to QDRO rejection.
 
@@ -123,7 +161,7 @@ Between the date of separation and QDRO approval, the account may gain or lose v
 
 ---
 
-## Steps to Divide the Amazon 401(K) Plan
+## Steps to Divide the Amazon 401(k) Plan
 
 1. **Request plan documents** — Get a current summary plan description and account statement from Amazon's benefits department
 
@@ -182,49 +220,4 @@ Consider seeking professional assistance if:
 
 **LexyAlgo** can generate a plan-specific QDRO draft for the Amazon 401(K) Plan at a flat fee. Our templates are designed to meet ERISA requirements and plan-specific guidelines.
 
-For full-service QDRO preparation, review, and filing, contact **Peacock QDROs & Divorce Law Firm, Attorney Willie Peacock** for expert assistance.
-
 > **Disclaimer reminder:** This page provides general information about the Amazon 401(K) Plan in the context of divorce. It does not constitute legal advice. Requirements and procedures can change. Always verify with the plan administrator and qualified legal counsel.
-
----
-
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  "mainEntity": [
-    {
-      "@type": "Question",
-      "name": "Can the Amazon 401(k) Plan be divided in divorce?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Yes. The marital portion of the Amazon 401(k) Plan may be divided in divorce through a Qualified Domestic Relations Order, depending on state law and the terms of the divorce judgment or settlement."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Do you need a QDRO for the Amazon 401(k) Plan?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Yes. Because the Amazon 401(k) Plan is an ERISA-qualified retirement plan, division in divorce typically requires a Qualified Domestic Relations Order approved by the plan administrator."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "What should a QDRO say about gains and losses?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "The QDRO should specify the valuation date and whether the alternate payee's share includes investment gains or losses between that date and the date the plan processes the order."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "How do plan loans affect division of an Amazon 401(k)?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "An outstanding participant loan can reduce the divisible balance or otherwise affect the award, so the QDRO and settlement terms should address how the loan is treated."
-      }
-    }
-  ]
-}
-</script>

--- a/content/posts/boeing-pension-qdro-guide.md
+++ b/content/posts/boeing-pension-qdro-guide.md
@@ -5,6 +5,66 @@ author: "William Peacock"
 description: "Learn how Boeing pension plans may be divided in divorce using a QDRO, including survivor benefits, frozen plan issues, and defined benefit rules."
 category: "QDRO"
 tags: ["QDRO", "boeing", "pension", "defined benefit", "divorce", "retirement"]
+schema_jsonld: |
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "How to Divide the Boeing Company Pension Plans in Divorce — QDRO Guide for Defined Benefit Plans",
+    "datePublished": "2026-04-01",
+    "dateModified": "2026-04-01",
+    "author": {
+      "@type": "Person",
+      "name": "William Peacock",
+      "url": "https://www.linkedin.com/in/williampeacock"
+    }
+  }
+faq_schema_jsonld: |
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Do I need a QDRO to divide a Boeing pension?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes. Defined benefit plans like Boeing's pensions generally require a qualified domestic relations order before they will assign any portion of a participant's benefit to an alternate payee."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What is the difference between separate interest and shared payment QDROs?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "A separate interest QDRO creates an independent benefit for the alternate payee. A shared payment QDRO gives the alternate payee a portion of each payment the participant actually receives. The available options depend on the specific Boeing pension plan."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How does a frozen pension affect division in divorce?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "A freeze typically means the benefit stopped growing under the prior formula after a certain date. It does not eliminate the alternate payee's right to their share of the accrued benefit, but it affects how the marital portion is measured."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What happens if the participant dies before retirement?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "If the QDRO does not address pre-retirement survivor benefits, the alternate payee may lose significant protection. Orders should expressly address qualified preretirement survivor annuity (QPSA) or equivalent plan protections where available."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Should I get professional help with a Boeing pension QDRO?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Defined benefit plans are complex. Professional help may be especially useful when the plan balance is significant, the participant is near retirement, the plan has frozen provisions, or a prior QDRO was rejected."
+        }
+      }
+    ]
+  }
 ---
 
 # How to Divide the Boeing Company Pension Plans in Divorce — QDRO Guide for Defined Benefit Plans
@@ -25,188 +85,82 @@ The two Boeing defined benefit plans identified here are:
 | EIN | 91-0425694 |
 | Plan Administrator | Employee Benefit Plans Committee |
 | Administrator Address | 929 Long Bridge Drive, Arlington, VA 22202 |
-| Most Recent Filing Year Referenced | 2024 |
-| Active Participants (2024 Form 5500 data) | ~30,211 for The Boeing Company Employee Retirement Plan; ~27,197 for The Pension Value Plan for Employees of The Boeing Company |
+| Most Recent Filing Year | 2024 |
+| Active Participants (2024 Form 5500 data) | ~30,211 for Employee Retirement Plan; ~27,197 for Pension Value Plan |
 
-A 401(k) division is often more straightforward because there is usually a current account balance that can be split by percentage or dollar amount as of a valuation date. A Boeing pension division is different because the order may need to address:
-
-- Whether the alternate payee receives a portion of a future monthly benefit
-- How the marital portion is calculated
-- When payments begin
-- Whether survivor protection is preserved
-- How plan-specific rules apply if accruals or participation were frozen
-
-That is why pension QDRO drafting usually requires more precision than a defined contribution plan order.
+A 401(k) division is often more straightforward because there is usually a current account balance that can be split by percentage or dollar amount as of a valuation date. A Boeing pension division is different because the order may need to address whether the alternate payee receives a portion of a future monthly benefit, how the marital portion is calculated, when payments begin, whether survivor protection is preserved, and how plan-specific rules apply if accruals were frozen. That is why pension QDRO drafting requires more precision than a defined contribution plan order.
 
 ## How Defined Benefit Plans Work in Divorce
 
-In a defined benefit plan, the benefit is typically expressed as a monthly payment at retirement, not merely as a cash balance available for immediate transfer. Even when a plan has a 'pension value' concept, the legal division still depends on the plan's governing terms and the domestic relations order accepted by the administrator.
+In a defined benefit plan, the benefit is typically expressed as a monthly payment at retirement, not merely as a cash balance available for immediate transfer. The legal division still depends on the plan's governing terms and the domestic relations order accepted by the administrator.
 
 Key concepts usually include:
 
-### Monthly Benefit vs. Account Balance
-A pension benefit is generally a promised retirement benefit payable in the future. Unlike a 401(k), there may be no simple participant account that can be carved out and rolled over. The order often assigns the alternate payee a share of a benefit payable under the plan.
+**Monthly Benefit vs. Account Balance.** A pension benefit is generally a promised retirement benefit payable in the future. Unlike a 401(k), there may be no simple participant account that can be carved out and rolled over. The order often assigns the alternate payee a share of a benefit payable under the plan.
 
-### Coverture Fraction
-Courts and drafters often use a **coverture fraction** to identify the marital portion of a pension. In plain English, that means comparing the period of pension service earned during the marriage to the total service credited under the plan. The marital portion is then divided according to the judgment, settlement, or applicable state law.
-
-### Marital Portion
-Not every dollar or every month of pension value is necessarily marital. If part of the participant's service occurred before marriage or after the marital cutoff date, those periods may be treated differently. The order should state clearly the date of marriage if relevant, the marital cutoff date, the formula used to calculate the marital share, and whether post-marital enhancements are included or excluded under the governing judgment.
-
-### Present Value vs. Deferred Division
-Sometimes spouses negotiate based on the present value of a pension for settlement purposes. But that valuation exercise is not the same thing as the actual plan division language. The QDRO or DRO still needs to tell the plan how benefits are to be paid. A settlement number alone does not divide the pension.
+**Marital Portion.** Not every dollar or every month of pension value is necessarily marital. If part of the participant's service occurred before marriage or after the marital cutoff date, those periods may be treated differently. The settlement or judgment should state clearly what portion is subject to division.
 
 ## Separate Interest vs. Shared Payment QDROs
 
 This is one of the most important decisions in a Boeing pension case.
 
-### Separate Interest Approach
-Under a separate interest structure, the alternate payee is assigned a portion of the participant's benefit that becomes the alternate payee's own separate benefit under the terms allowed by the plan. In plans that permit it, this may allow the alternate payee to begin benefits at a time allowed by the plan, even if the participant has not yet retired.
+**Separate Interest.** Under a separate interest structure, the alternate payee is assigned a portion of the participant's benefit that becomes the alternate payee's own separate benefit under the terms allowed by the plan. This may allow the alternate payee to begin benefits at a time allowed by the plan, even if the participant has not yet retired. This can reduce dependence on the participant's retirement timing and help define the share more cleanly.
 
-Why it matters:
-- It can reduce dependence on the participant's retirement timing
-- It can help define the alternate payee's share more cleanly
-- It may affect actuarial conversion, commencement timing, and survivor issues
+**Shared Payment.** Under a shared payment structure, the alternate payee receives a portion of each payment when and if the participant receives it. In that setup, payment to the alternate payee is often tied to the participant's actual retirement. The alternate payee may have to wait until the participant begins receiving benefits, and survivor provisions become especially important.
 
-### Shared Payment Approach
-Under a shared payment structure, the alternate payee receives a portion of each payment when and if the participant receives it. In that setup, payment to the alternate payee is often tied to the participant's actual retirement and receipt of benefits.
-
-Why it matters:
-- The alternate payee may have to wait until the participant begins receiving benefits
-- If the participant delays retirement, that delay may affect when the alternate payee is paid
-- Survivor and death provisions become especially important
-
-### Why the Choice Matters in Boeing Pension Cases
-For a large employer pension like Boeing's, the acceptable structure depends on the plan's written terms and QDRO procedures. The order should not assume that every option is available in every Boeing pension arrangement. Before submitting an order, confirm with the plan administrator:
-
-- Whether separate interest treatment is permitted
-- Whether only shared payment language is accepted for a particular benefit
-- What earliest retirement assumptions apply
-- How the plan handles commencement elections and actuarial adjustments
+For a large employer pension like Boeing's, the acceptable structure depends on the plan's written terms and QDRO procedures. Confirm with the plan administrator whether separate interest treatment is permitted and how the plan handles commencement elections.
 
 ## Survivor Benefits: Pre-Retirement and Post-Retirement
 
 Survivor language is where a lot of pension orders go sideways.
 
-### Pre-Retirement Survivor Protection
-If the participant dies before retirement, the alternate payee may lose significant value unless the order properly addresses pre-retirement survivor rights where available. In many pension contexts, this involves the qualified preretirement survivor annuity (QPSA) or comparable survivor protection recognized by the plan. If the order is silent, the alternate payee may not receive what the parties expected.
+**Pre-Retirement Survivor Protection.** If the participant dies before retirement, the alternate payee may lose significant value unless the order properly addresses pre-retirement survivor rights where available, such as the qualified preretirement survivor annuity (QPSA). If the order is silent, the alternate payee may not receive what was expected.
 
-### Post-Retirement Survivor Benefits
-If the participant retires and elects a form of benefit with survivor options, the QDRO should address whether the alternate payee is to be treated as surviving spouse for all or part of the assigned share, where permitted. If not addressed correctly, retirement elections can materially affect the value of the alternate payee's interest.
+**Post-Retirement Survivor Benefits.** If the participant retires and elects a form of benefit with survivor options, the QDRO should address whether the alternate payee is to be protected. Retirement elections can materially affect the value of the alternate payee's interest.
 
-### Why This Must Be Addressed
-A pension is not just about the monthly amount while everyone is alive. The order may also need to specify:
-
-- Whether the alternate payee is protected before retirement
-- Whether survivor annuity rights are assigned
-- What happens if the participant dies before commencement
-- What happens if the participant dies after commencement
-- Whether the alternate payee's share continues, ends, or converts under plan rules
-
-These are plan-specific issues, so always verify with the administrator before finalizing language.
+A pension is not just about the monthly amount while everyone is alive. The order may also need to specify whether the alternate payee is protected before retirement, whether survivor annuity rights are assigned, what happens if the participant dies before or after commencement, and whether the alternate payee's share continues or ends under plan rules. Always verify with the administrator before finalizing language.
 
 ## Frozen Coverage Issues (Important for Boeing)
 
-This is especially important for Boeing pension analysis.
+Many legacy defined benefit plans have been frozen in some way. A freeze can mean no new participants, no future benefit accruals after a certain date, no additional credited service, or conversion into a preserved accrued benefit with later payment at retirement.
 
-Many legacy defined benefit plans have been frozen in some way. A freeze can mean different things depending on the plan:
+If a Boeing pension benefit was frozen, that usually does **not** mean the benefit disappeared. It generally means the accrued benefit stopped growing under the prior formula after a certain date. For divorce purposes, that can affect how the marital portion is measured and how the alternate payee's share should be expressed.
 
-- No new participants
-- No future benefit accruals after a certain date
-- No additional credited service for formula purposes after a freeze date
-- Conversion into a preserved accrued benefit with later payment at retirement
-
-### What 'Frozen' Means in Divorce Planning
-If a Boeing pension benefit was frozen, that usually does **not** mean the benefit disappeared. It generally means the accrued benefit stopped growing under the prior formula after a certain date, subject to the actual plan terms.
-
-For divorce purposes, that can affect:
-
-- How the marital portion is measured
-- Whether the coverture formula should stop at the freeze date or continue through another date
-- Whether post-freeze subsidies or early retirement features are still relevant
-- How the alternate payee's share should be expressed
-
-### Does the Alternate Payee Still Receive a Share If the Plan Is Frozen?
-Often, yes — assuming there is a valid domestic relations order and the assigned benefit exists under the plan. A freeze typically affects future accrual mechanics, not the fact that an accrued pension benefit may still be divided. But the exact result depends on the plan's terms, the participant's status, whether the benefit was already accrued during the marriage, and whether the order properly defines the alternate payee's share.
+The alternate payee can still receive a share of the accrued benefit assuming there is a valid domestic relations order. A freeze affects future accrual mechanics, not the fact that an accrued pension benefit may still be divided. But the exact result depends on the plan's terms, the participant's status, and whether the order properly defines the alternate payee's share.
 
 This is one reason generic pension language can be dangerous in Boeing cases. Frozen benefit structures need careful drafting so the order matches the plan's actual benefit design.
 
 ## QDRO Requirements for Boeing Pensions
 
-A Boeing pension order should be drafted with the actual plan procedures in mind, not from a generic template.
-
 ### Plan Administrator Contact
-**Plan Administrator:** Employee Benefit Plans Committee
-**Address:** 929 Long Bridge Drive, Arlington, VA 22202
+Plan Administrator: Employee Benefit Plans Committee
+Address: 929 Long Bridge Drive, Arlington, VA 22202
 
-Before submission, confirm current QDRO review procedures, whether the plan provides model language, whether there are separate procedures for the two Boeing pension plans, whether pre-approval review is available, and the correct mailing or upload instructions.
+Before submission, confirm current QDRO review procedures, whether the plan provides model language, whether there are separate procedures for the two Boeing pension plans, and the correct filing instructions.
 
 ### Key Issues the Order Should Address
-A Boeing pension order commonly needs to identify, with precision:
-
-1. **The correct plan name** — The order should clearly state whether it applies to The Boeing Company Employee Retirement Plan, The Pension Value Plan for Employees of The Boeing Company, or both, if appropriate and supported by the judgment.
-
-2. **The participant and alternate payee** — Full identifying information is usually required in the order or submission materials.
-
-3. **The formula or amount assigned** — The order should clearly state percentage, fraction, or formula; marital fraction if used; valuation or cutoff date; and whether gains, losses, actuarial adjustments, or subsidies are included.
-
-4. **Separate interest vs. shared payment structure** — The order should not leave this ambiguous. The accepted structure must match the plan's rules.
-
-5. **Survivor benefit provisions** — The order should expressly address pre-retirement and post-retirement death protection where available.
-
-6. **Commencement date** — The order should specify when the alternate payee may begin receiving benefits, consistent with the plan's terms.
-
-7. **Benefit form and limitations** — The order cannot require the plan to provide a form or benefit not otherwise available under the plan.
-
-Always verify with Boeing's plan administrator before finalizing.
+1. **The correct plan name** — specify which Boeing pension plan is being divided
+2. **Participant and alternate payee identification**
+3. **Formula or amount assigned** — percentage, fraction, or valuation date
+4. **Separate interest vs. shared payment structure** — the accepted structure must match the plan's rules
+5. **Survivor benefit provisions** — pre-retirement and post-retirement
+6. **Commencement date** — when the alternate payee may begin receiving benefits
+7. **Benefit form and limitations** — the order cannot require the plan to provide a form not otherwise available
 
 ## Common Mistakes to Avoid
 
-1. **Failing to address survivor benefits** — If the order does not address survivor rights, the alternate payee may lose valuable protection.
-
-2. **Not understanding frozen coverage rules** — Boeing's defined benefit plans may have frozen coverage. This affects how the marital portion is calculated. Verify with the plan administrator whether your state is affected.
-
-3. **Using a regular court order** — A pension division requires a QDRO, not a standard divorce judgment.
-
-4. **Not addressing the pre-retirement phase** — If the participant dies before both retiring and before the ex-spouse files for benefits, the alternate payee may lose everything except whatever pre-retirement survivor benefits are available. You must address this in your QDRO.
-
-5. **Waiting too long** — Waiting until after the divorce (or worse, years later) to file a pension QDRO makes everything harder. Lost records, changed administrators, soured relationships — all of it. Waiting makes this harder and, in some cases, impossible.
+1. **Failing to address survivor benefits** — if the order is silent and the participant dies, the alternate payee may lose valuable protection
+2. **Not understanding frozen coverage rules** — verify with the plan administrator how any freeze affects division
+3. **Using a regular court order** — a pension division requires a QDRO, not a standard divorce judgment
+4. **Not addressing the pre-retirement phase** — without pre-retirement survivor protections, the alternate payee may lose everything if the participant dies before retirement benefits commence
+5. **Waiting too long** — lost records, changed administrators, and soured relationships make delayed filings harder and sometimes impossible
 
 ## When to Get Help
 
-Defined benefit plans are the most complex type of retirement plan to divide. Consider professional assistance if:
+Defined benefit plans are the most complex type of retirement plan to divide. Professional help may be especially useful when the participant is near or at retirement, the pension has frozen coverage, the present value is significant, multi-state employment is involved, complex survivor provisions apply, a prior QDRO was rejected, or plan records are lost or unavailable.
 
-- The participant is near or at retirement
-- The pension has frozen coverage provisions
-- The value is significant (over $250,000 in present value)
-- Multi-state employment history is involved
-- The QDRO needs to address complex survivor or early retirement benefits
-- A prior QDRO has been rejected by the plan
-- Plan records are lost or unavailable
+## About LexyAlgo
 
-## About LexyAlgo and Peacock QDROs & Divorce Law Firm
-
-**LexyAlgo** provides **automated QDRO drafting** tools designed to support more efficient preparation of plan division documents. Pension-specific templates can help ensure defined benefit requirements are addressed.
-
-For full-service help, the firm name is **Peacock QDROs & Divorce Law Firm**, led by **Attorney William Peacock**. If a case involves complex tracing issues, high balances, prior rejected orders, or state-specific complications, full-service legal support may be appropriate. [Connect with William Peacock on LinkedIn](https://www.linkedin.com/in/williampeacock).
-
-Neither automated drafting nor law firm representation guarantees any particular outcome. The right path depends on the facts, the governing state law, the settlement terms, and the plan's own review requirements.
-
-## FAQ
-
-**Do I need a QDRO to divide a Boeing pension?**
-Yes. Defined benefit plans like Boeing's pensions generally require a qualified domestic relations order (QDRO) before they will assign any portion of a participant's benefit to an alternate payee.
-
-**What is the difference between separate interest and shared payment QDROs?**
-A separate interest QDRO creates an independent benefit for the alternate payee, while a shared payment QDRO gives the alternate payee a portion of each payment the participant actually receives. The available options depend on the specific Boeing pension plan.
-
-**How does a frozen pension affect division in divorce?**
-A freeze typically means the benefit stopped growing under the prior formula after a certain date. It does not eliminate the alternate payee's right to their share of the accrued benefit, but it affects how the marital portion is measured.
-
-**What happens if the participant dies before retirement?**
-If the QDRO does not address pre-retirement survivor benefits, the alternate payee may lose significant protection. Orders should expressly address qualified preretirement survivor annuity (QPSA) or equivalent plan protections where available.
-
-**Should I get professional help with a Boeing pension QDRO?**
-Defined benefit plans are complex. Professional help may be especially useful when the balance is significant, the participant is near retirement, the plan has frozen provisions, or a prior QDRO was rejected.
+**LexyAlgo** can generate a plan-specific QDRO draft for Boeing pension plans at a flat fee. Our templates account for defined benefit plan requirements, including separate interest vs. shared payment structures, survivor benefit provisions, and frozen coverage considerations.
 
 > **Disclaimer:** This page is not legal advice and does not create an attorney-client relationship. Plan procedures, court requirements, and state-law property rules vary. Always verify current requirements directly with the Boeing plan administrator before relying on any draft or division formula.


### PR DESCRIPTION
## Summary

Revised both plan profile articles based on Willie audio feedback:

### Changes made:
- **Removed raw JSON-LD script tags** from article body — moved schema to frontmatter fields so the site injects it properly instead of dumping raw markup on the page
- **LexyAlgo-only CTAs** — removed Peacock QDROs / Willie Peacock callouts; LexyAlgo articles call out only LexyAlgo
- **Removed visible LinkedIn link from article body** — LinkedIn stays in author schema frontmatter only (SEO backend), not in readable text
- **Amazon 401(k):** cleaned up coverture formula language for a 401(k) / deferred comp article (QDRO specifies the award; plan calculates; no coverture formula baked into the order)
- **Boeing pension:** completed truncated common mistakes section
- **Both:** proper FAQ schema in frontmatter, Article/Author schema in frontmatter with William Peacock + LinkedIn URL

### Files changed:
- `content/posts/amazon-401k-qdro-guide.md`
- `content/posts/boeing-pension-qdro-guide.md`

### Reviewers:
- @peacockesq (content)
- @otto (code review)
- @Alfred (staging verification)

cc @jameela