### PR TITLE
chore: add deploy runbook and static artifact workflow

### DIFF
--- a/.github/workflows/build-static-export.yml
+++ b/.github/workflows/build-static-export.yml
@@ -1,0 +1,37 @@
+name: Build static export
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build static export
+        run: npm run build
+
+      - name: Upload static artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: site-out
+          path: out
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ npm run build
 
 Static output goes to `/out/`.
 
+## Deployment
+
+This repo builds to a static export and does not currently auto-publish to `lexyalgo.com`.
+
+- GitHub Actions now builds a deployable static artifact on every push to `main` and on manual dispatch.
+- The artifact name is `site-out` and contains the contents of `/out/`.
+- To publish a release, download the latest successful `Build static export` artifact and sync its contents to the web root on the Hostinger nginx host that serves `lexyalgo.com`.
+
+Detailed runbook: [`docs/deployment.md`](docs/deployment.md)
+
 ## Environment Variables
 
 - `NEXT_PUBLIC_VBOUT_API_KEY` — VBOUT email marketing API key for waitlist signups

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,70 @@
+# LexyAlgo deployment runbook
+
+## Current hosting shape
+
+Known production proof from issue tracking:
+
+- `lexyalgo.com` is serving through nginx on a Hostinger-hosted server.
+- The site is a static Next.js export.
+- This repository is the source of truth for the build, but production publishing has been happening outside the repo.
+
+## Build artifact
+
+The canonical deployable artifact is the `out/` directory produced by:
+
+```bash
+npm ci
+npm run build
+```
+
+GitHub Actions publishes this directory as an artifact named `site-out` on every push to `main` and on manual runs.
+
+## Release procedure
+
+1. Open the latest successful **Build static export** workflow run for `main`.
+2. Download the `site-out` artifact.
+3. Extract the artifact locally.
+4. Sync the extracted files to the nginx web root that serves `lexyalgo.com`.
+5. Verify the live site matches current `main`.
+
+## Suggested host-side sync commands
+
+Adjust paths/usernames to match the actual Hostinger setup.
+
+```bash
+rsync -av --delete ./out/ user@host:/var/www/lexyalgo.com/
+```
+
+If the artifact is downloaded as a zip/tar bundle, extract it first, then sync the exported files.
+
+## Verification checklist
+
+After deploy, verify at least:
+
+- `/`
+- `/pricing`
+- `/terms`
+- `/privacy`
+- `/contact`
+
+Recommended proof commands:
+
+```bash
+curl -I https://lexyalgo.com/
+curl -I https://lexyalgo.com/pricing
+curl -I https://lexyalgo.com/terms
+curl -I https://lexyalgo.com/privacy
+curl -I https://lexyalgo.com/contact
+```
+
+Capture the workflow run URL, artifact run SHA, and verification output in the linked issue or PR.
+
+## Follow-up automation options
+
+Once Hostinger access is confirmed, upgrade this from build-only to full deployment by choosing one of:
+
+1. GitHub Actions + SSH/rsync to the Hostinger box
+2. GitHub Actions + SCP upload + atomic symlink switch on host
+3. Move hosting to a repo-connected static platform if operationally simpler
+
+Until host credentials and target paths are confirmed, this repo intentionally stops at producing a proof-backed deployable artifact.


### PR DESCRIPTION
## Summary
- add a repo-local deployment runbook for lexyalgo.com
- add a GitHub Actions workflow that builds the static Next.js export on pushes to main and manual dispatch
- document the artifact-based release path in the README

## Why
Production drift is currently caused by an external/manual Hostinger publish path with no repo-local deployment proof. This PR puts the missing repo-side release discipline in place so issue #20 has a concrete fix path and issue #19 can use a canonical build artifact for redeploy.

Closes #20
Supports #19

## Proof
- `npm ci`
- `npm run lint`
- `npm run build`
- build generated the full static route set, including `/pricing`, `/terms`, `/privacy`, and `/contact`

## Follow-up
Once Hostinger access and target paths are confirmed, the workflow can be upgraded from artifact-only to SSH/SCP deployment.
