### PR TITLE
Fix mission-page US spelling and hide draft blog posts

### DIFF
--- a/content/posts/coparenting-communication-tips.md
+++ b/content/posts/coparenting-communication-tips.md
@@ -3,6 +3,7 @@ title: 5 Communication Strategies That Actually Reduce Co-Parenting Conflict
 date: 2026-03-14T09:00:00.000Z
 author: LexyAlgo Team
 excerpt: Small language shifts and tighter systems can reduce conflict, improve documentation, and make co-parenting communication more predictable.
+draft: true
 seo:
   title: Co-Parenting Communication Tips — LexyAlgo
   description: Practical co-parenting communication strategies that reduce conflict and create cleaner documentation.

--- a/content/posts/retirement-accounts-divorce.md
+++ b/content/posts/retirement-accounts-divorce.md
@@ -3,6 +3,7 @@ title: "Retirement Accounts in Divorce: Why $30K Today Isn't the Same as $30K in
 date: 2026-03-18T09:00:00.000Z
 author: LexyAlgo Team
 excerpt: People trade retirement assets for cash all the time without pricing in taxes, growth, or withdrawal rules. Here is the simpler way to think about it.
+draft: true
 seo:
   title: Retirement Accounts in Divorce — LexyAlgo
   description: See why retirement balances should not be treated like cash when dividing assets in divorce.

--- a/content/posts/understanding-asset-division.md
+++ b/content/posts/understanding-asset-division.md
@@ -3,6 +3,7 @@ title: "Understanding Asset Division: What You Need to Know Before You Start"
 date: 2026-03-22T09:00:00.000Z
 author: LexyAlgo Team
 excerpt: A practical guide to marital property vs. separate property, community property vs. equitable distribution states, and the biggest mistakes people make when dividing assets.
+draft: true
 seo:
   title: Understanding Asset Division Before Divorce — LexyAlgo
   description: Learn the basics of marital vs. separate property, how different states handle division, and how to avoid common asset-splitting mistakes.

--- a/src/app/mission/page.tsx
+++ b/src/app/mission/page.tsx
@@ -23,7 +23,7 @@ export default function MissionPage() {
         <div className="prose prose-slate prose-lg max-w-none">
           <div className="space-y-6 text-slate-700 leading-relaxed">
             <p className="text-xl text-slate-900 font-medium">
-              I&rsquo;ve practised family law across eight states. I&rsquo;ve drafted thousands of QDROs, reviewed tens of thousands of retirement accounts, and watched how people make decisions at the worst moments of their lives.
+              I&rsquo;ve practiced family law across eight states. I&rsquo;ve drafted thousands of QDROs, reviewed tens of thousands of retirement accounts, and watched how people make decisions at the worst moments of their lives.
             </p>
 
             <p>

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -15,6 +15,7 @@ export type Post = {
   excerpt?: string
   body: string
   seo?: SeoFields
+  draft?: boolean
 }
 
 const postsDirectory = path.join(process.cwd(), 'content', 'posts')
@@ -50,8 +51,10 @@ export function getAllPosts(): Post[] {
               description: typeof data.seo.description === 'string' ? data.seo.description : undefined,
             }
           : undefined,
+        draft: data.draft === true,
       }
     })
+    .filter((post) => !post.draft)
     .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
 }
 


### PR DESCRIPTION
## Summary\n- switch the mission page copy from British to American spelling\n- add draft filtering to blog content loading\n- hide the three placeholder/generic posts so the public blog only shows the real QDRO guides\n\n## Verification\n- npm run lint\n- npm run build\n\nCloses #5