### PR TITLE
Fix contact form delivery path and anti-spam for issue #24

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -37,6 +37,20 @@ rsync -av --delete ./out/ user@host:/var/www/lexyalgo.com/
 
 If the artifact is downloaded as a zip/tar bundle, extract it first, then sync the exported files.
 
+## Contact form activation
+
+The `/contact` page now posts to `https://formsubmit.co/hello@lexyalgo.com` so the static site has a real delivery path without adding server infrastructure.
+
+After the first live submission, FormSubmit will send an activation email to `hello@lexyalgo.com`. Someone with inbox access must click that activation link once before future submissions will deliver normally.
+
+Contact form checks after deploy:
+
+1. Submit a test message on `/contact`
+2. Confirm the browser lands on `/contact/thanks`
+3. Confirm the activation email or submission email arrives in `hello@lexyalgo.com`
+4. If activation was required, click it and repeat one more test submission
+5. Confirm the honeypot field stays empty in the delivered message and CAPTCHA challenged the browser as expected
+
 ## Verification checklist
 
 After deploy, verify at least:
@@ -46,6 +60,7 @@ After deploy, verify at least:
 - `/terms`
 - `/privacy`
 - `/contact`
+- `/contact/thanks`
 
 Recommended proof commands:
 

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -3,6 +3,9 @@ const contactInfo = [
   { label: 'Email', value: 'hello@lexyalgo.com', icon: '✉️' },
 ]
 
+const formAction = 'https://formsubmit.co/hello@lexyalgo.com'
+const thankYouUrl = 'https://lexyalgo.com/contact/thanks'
+
 export default function ContactPage() {
   return (
     <>
@@ -31,42 +34,106 @@ export default function ContactPage() {
               </div>
             ))}
 
-            <div className="bg-slate-100 rounded-2xl p-6 mt-8">
+            <div className="bg-slate-100 rounded-2xl p-6 mt-8 space-y-3">
               <p className="text-xs text-slate-500 italic">
                 LexyAlgo provides document preparation tools, not legal advice. If you need an attorney, we&rsquo;re happy to point you in the right direction.
+              </p>
+              <p className="text-xs text-slate-500">
+                Phone support stays hidden until a verified LexyAlgo support number is confirmed.
               </p>
             </div>
           </div>
 
           {/* Contact form */}
           <div className="lg:col-span-2">
-            <div className="bg-white rounded-2xl border border-slate-200 p-8 sm:p-10 space-y-6">
-              <div className="rounded-2xl border border-amber-200 bg-amber-50 p-5">
-                <p className="text-sm font-semibold text-amber-900">Secure contact form coming soon</p>
-                <p className="mt-2 text-sm text-amber-800">
-                  We are replacing the old placeholder form with a verified delivery path and anti-spam protection.
-                  Until that is live, please email us directly so your message reaches a real inbox.
+            <form
+              action={formAction}
+              method="POST"
+              className="bg-white rounded-2xl border border-slate-200 p-8 sm:p-10 space-y-6"
+            >
+              <div className="rounded-2xl border border-teal/20 bg-teal/5 p-5">
+                <p className="text-sm font-semibold text-slate-900">Verified inbox delivery is now wired for the static site</p>
+                <p className="mt-2 text-sm text-slate-700">
+                  Messages submit through FormSubmit with email verification, built-in CAPTCHA, and a hidden honeypot field for spam filtering.
                 </p>
               </div>
 
-              <div className="space-y-3">
-                <h3 className="font-[family-name:var(--font-space)] font-bold text-xl text-slate-900">Email LexyAlgo</h3>
-                <p className="text-slate-600">
-                  For product questions, partnership inquiries, or support, email us and we&rsquo;ll reply within one business day.
-                </p>
-              </div>
+              <input type="hidden" name="_subject" value="New LexyAlgo contact form submission" />
+              <input type="hidden" name="_next" value={thankYouUrl} />
+              <input type="hidden" name="_template" value="table" />
+              <input type="text" name="_honey" className="hidden" tabIndex={-1} autoComplete="off" />
 
-              <a
-                href="mailto:hello@lexyalgo.com?subject=LexyAlgo%20inquiry"
-                className="inline-flex items-center justify-center bg-teal text-white font-semibold px-8 py-3 rounded-xl hover:bg-[#12434D] transition-all shadow-sm shadow-teal/20 active:scale-[0.98]"
-              >
-                Email hello@lexyalgo.com
-              </a>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+                <div>
+                  <label htmlFor="name" className="block text-sm font-medium text-slate-700 mb-2">Name</label>
+                  <input
+                    id="name"
+                    name="name"
+                    type="text"
+                    placeholder="Your name"
+                    className="w-full px-4 py-3 rounded-xl border border-slate-200 text-sm focus:outline-none focus:ring-2 focus:ring-teal/20 focus:border-teal"
+                    required
+                  />
+                </div>
+                <div>
+                  <label htmlFor="email" className="block text-sm font-medium text-slate-700 mb-2">Email</label>
+                  <input
+                    id="email"
+                    name="email"
+                    type="email"
+                    placeholder="you@email.com"
+                    className="w-full px-4 py-3 rounded-xl border border-slate-200 text-sm focus:outline-none focus:ring-2 focus:ring-teal/20 focus:border-teal"
+                    required
+                  />
+                </div>
+              </div>
+              <div>
+                <label htmlFor="subject" className="block text-sm font-medium text-slate-700 mb-2">Subject</label>
+                <select
+                  id="subject"
+                  name="topic"
+                  className="w-full px-4 py-3 rounded-xl border border-slate-200 text-sm focus:outline-none focus:ring-2 focus:ring-teal/20 focus:border-teal text-slate-700"
+                  defaultValue="General inquiry"
+                >
+                  <option>General inquiry</option>
+                  <option>Calculator question</option>
+                  <option>Product feedback</option>
+                  <option>Partnership / integration</option>
+                  <option>Press / media</option>
+                  <option>Other</option>
+                </select>
+              </div>
+              <div>
+                <label htmlFor="message" className="block text-sm font-medium text-slate-700 mb-2">Message</label>
+                <textarea
+                  id="message"
+                  name="message"
+                  rows={6}
+                  placeholder="How can we help?"
+                  className="w-full px-4 py-3 rounded-xl border border-slate-200 text-sm focus:outline-none focus:ring-2 focus:ring-teal/20 focus:border-teal resize-none"
+                  required
+                />
+              </div>
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <button
+                  type="submit"
+                  className="inline-flex items-center justify-center bg-teal text-white font-semibold px-8 py-3 rounded-xl hover:bg-[#12434D] transition-all shadow-sm shadow-teal/20 active:scale-[0.98]"
+                >
+                  Send Message
+                </button>
+
+                <a
+                  href="mailto:hello@lexyalgo.com?subject=LexyAlgo%20inquiry"
+                  className="text-sm font-medium text-teal hover:text-[#12434D]"
+                >
+                  Prefer email? hello@lexyalgo.com
+                </a>
+              </div>
 
               <p className="text-xs text-slate-500">
-                We are intentionally hiding phone support here until a verified LexyAlgo support number is confirmed.
+                If this is the first live submission after deploy, FormSubmit will send an activation email to hello@lexyalgo.com before future messages start delivering.
               </p>
-            </div>
+            </form>
           </div>
         </div>
       </section>

--- a/src/app/contact/thanks/page.tsx
+++ b/src/app/contact/thanks/page.tsx
@@ -1,0 +1,28 @@
+export default function ContactThanksPage() {
+  return (
+    <section className="bg-gradient-to-b from-surface to-white py-20 sm:py-28">
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+        <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-teal/10 text-3xl">
+          ✓
+        </div>
+        <h1 className="mt-6 font-[family-name:var(--font-space)] text-4xl font-bold text-slate-900">
+          Thanks, we got your message
+        </h1>
+        <p className="mt-4 text-lg text-slate-600">
+          A LexyAlgo team member should reply within one business day.
+        </p>
+        <p className="mt-3 text-sm text-slate-500">
+          If you do not hear back, email hello@lexyalgo.com directly.
+        </p>
+        <div className="mt-8">
+          <a
+            href="/"
+            className="inline-flex items-center justify-center rounded-xl bg-teal px-8 py-3 font-semibold text-white transition-all hover:bg-[#12434D]"
+          >
+            Back to LexyAlgo
+          </a>
+        </div>
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- replace the temporary mailto-only fallback with a real static form POST to FormSubmit
- add a dedicated /contact/thanks confirmation page and keep direct email as backup
- document the one-time inbox activation + post-deploy verification steps in the deployment runbook

## Proof
- npm run lint
- npm run build
- built export contains form action `https://formsubmit.co/hello@lexyalgo.com`
- built export contains `/contact/thanks`

## Remaining blocker
- someone with access to hello@lexyalgo.com must click the one-time FormSubmit activation email after the first live submission so delivery is fully active

Refs #24