### PR TITLE
chore: add Hostinger deploy workflow for issue #27

### DIFF
--- a/.github/workflows/deploy-static-export.yml
+++ b/.github/workflows/deploy-static-export.yml
@@ -23,10 +23,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: lexyalgo-site-${{ github.event_name == 'push' && 'production' || inputs.environment }}
-  cancel-in-progress: false
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -183,12 +179,16 @@ jobs:
             out/ "$DEPLOY_USER@$DEPLOY_HOST:$DEPLOY_PATH/"
 
       - name: Verify deployed build metadata
-        if: ${{ secrets.DEPLOY_BASE_URL != '' }}
         env:
           DEPLOY_BASE_URL: ${{ secrets.DEPLOY_BASE_URL }}
           EXPECTED_SHA: ${{ needs.build.outputs.deploy_sha }}
         shell: bash
         run: |
+          if [ -z "$DEPLOY_BASE_URL" ]; then
+            echo "DEPLOY_BASE_URL not set for this environment, skipping URL verification."
+            exit 0
+          fi
+
           curl --fail --silent --show-error "$DEPLOY_BASE_URL/build-meta.json" --output deployed-build-meta.json
           python3 <<'PY'
           import json

--- a/.github/workflows/deploy-static-export.yml
+++ b/.github/workflows/deploy-static-export.yml
@@ -1,0 +1,204 @@
+name: Deploy static export
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target GitHub environment with Hostinger deploy secrets
+        required: true
+        default: staging
+        type: choice
+        options:
+          - staging
+          - production
+      ref:
+        description: Git ref to build and deploy
+        required: true
+        default: main
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lexyalgo-site-${{ github.event_name == 'push' && 'production' || inputs.environment }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      deploy_environment: ${{ steps.meta.outputs.deploy_environment }}
+      deploy_ref: ${{ steps.meta.outputs.deploy_ref }}
+      deploy_sha: ${{ steps.sha.outputs.deploy_sha }}
+    steps:
+      - name: Resolve deploy target
+        id: meta
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "deploy_environment=production" >> "$GITHUB_OUTPUT"
+            echo "deploy_ref=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+          else
+            echo "deploy_environment=${{ inputs.environment }}" >> "$GITHUB_OUTPUT"
+            echo "deploy_ref=${{ inputs.ref }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check out deploy ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.meta.outputs.deploy_ref }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build static export
+        run: npm run build
+
+      - name: Resolve built commit SHA
+        id: sha
+        shell: bash
+        run: echo "deploy_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Stamp static artifact with build metadata
+        env:
+          DEPLOY_ENVIRONMENT: ${{ steps.meta.outputs.deploy_environment }}
+          DEPLOY_REF: ${{ steps.meta.outputs.deploy_ref }}
+          DEPLOY_SHA: ${{ steps.sha.outputs.deploy_sha }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          RUN_NUMBER: ${{ github.run_number }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          REPOSITORY: ${{ github.repository }}
+          REPOSITORY_URL: ${{ github.server_url }}/${{ github.repository }}
+        shell: bash
+        run: |
+          export BUILT_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          python3 <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          payload = {
+              "environment": os.environ["DEPLOY_ENVIRONMENT"],
+              "ref": os.environ["DEPLOY_REF"],
+              "sha": os.environ["DEPLOY_SHA"],
+              "runId": os.environ["RUN_ID"],
+              "runAttempt": os.environ["RUN_ATTEMPT"],
+              "runNumber": os.environ["RUN_NUMBER"],
+              "workflow": os.environ["WORKFLOW_NAME"],
+              "repository": os.environ["REPOSITORY"],
+              "repositoryUrl": os.environ["REPOSITORY_URL"],
+              "builtAt": os.environ["BUILT_AT"],
+          }
+
+          path = Path("out/build-meta.json")
+          path.parent.mkdir(parents=True, exist_ok=True)
+          path.write_text(json.dumps(payload, indent=2) + "\n")
+          print(path.read_text())
+          PY
+
+      - name: Upload static export artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: static-export
+          path: out
+          if-no-files-found: error
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: ${{ needs.build.outputs.deploy_environment }}
+    steps:
+      - name: Download static export artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: static-export
+          path: out
+
+      - name: Install SSH tooling
+        run: sudo apt-get update && sudo apt-get install -y rsync openssh-client
+
+      - name: Configure SSH access
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
+          DEPLOY_KNOWN_HOSTS: ${{ secrets.DEPLOY_KNOWN_HOSTS }}
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+        shell: bash
+        run: |
+          if [ -z "$DEPLOY_HOST" ] || [ -z "$DEPLOY_SSH_KEY" ]; then
+            echo "Missing DEPLOY_HOST or DEPLOY_SSH_KEY for environment ${{ needs.build.outputs.deploy_environment }}" >&2
+            exit 1
+          fi
+
+          port="$DEPLOY_PORT"
+          [ -n "$port" ] || port=22
+
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "$DEPLOY_SSH_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+
+          if [ -n "$DEPLOY_KNOWN_HOSTS" ]; then
+            printf '%s\n' "$DEPLOY_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          else
+            ssh-keyscan -p "$port" "$DEPLOY_HOST" >> ~/.ssh/known_hosts
+          fi
+          chmod 644 ~/.ssh/known_hosts
+
+      - name: Sync artifact to Hostinger
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+          DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+        shell: bash
+        run: |
+          if [ -z "$DEPLOY_HOST" ] || [ -z "$DEPLOY_USER" ] || [ -z "$DEPLOY_PATH" ]; then
+            echo "Missing one of DEPLOY_HOST, DEPLOY_USER, or DEPLOY_PATH" >&2
+            exit 1
+          fi
+
+          port="$DEPLOY_PORT"
+          [ -n "$port" ] || port=22
+
+          rsync \
+            --archive \
+            --compress \
+            --delete \
+            --human-readable \
+            -e "ssh -i ~/.ssh/id_ed25519 -p $port" \
+            out/ "$DEPLOY_USER@$DEPLOY_HOST:$DEPLOY_PATH/"
+
+      - name: Verify deployed build metadata
+        if: ${{ secrets.DEPLOY_BASE_URL != '' }}
+        env:
+          DEPLOY_BASE_URL: ${{ secrets.DEPLOY_BASE_URL }}
+          EXPECTED_SHA: ${{ needs.build.outputs.deploy_sha }}
+        shell: bash
+        run: |
+          curl --fail --silent --show-error "$DEPLOY_BASE_URL/build-meta.json" --output deployed-build-meta.json
+          python3 <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          payload = json.loads(Path("deployed-build-meta.json").read_text())
+          expected = os.environ["EXPECTED_SHA"]
+          actual = payload.get("sha")
+          if actual != expected:
+              raise SystemExit(f"deploy verification failed: expected {expected}, got {actual}")
+          print(json.dumps(payload, indent=2))
+          PY

--- a/README.md
+++ b/README.md
@@ -43,13 +43,16 @@ Static output goes to `/out/`.
 
 ## Deployment
 
-This repo builds to a static export and does not currently auto-publish to `lexyalgo.com`.
+This repo builds to a static export and now includes a GitHub Actions deploy workflow for Hostinger-backed staging and production releases.
 
-- GitHub Actions now builds a deployable static artifact on every push to `main` and on manual dispatch.
-- The artifact name is `site-out` and contains the contents of `/out/`.
-- To publish a release, download the latest successful `Build static export` artifact and sync its contents to the web root on the Hostinger nginx host that serves `lexyalgo.com`.
+- Pushes to `main` build, lint, stamp `out/build-meta.json`, and deploy through the `production` GitHub environment.
+- Manual workflow dispatch can deploy any ref to `staging` or `production` once environment secrets are configured.
+- The deployable build artifact is the `static-export` Actions artifact, containing the contents of `/out/`.
 
-Detailed runbook: [`docs/deployment.md`](docs/deployment.md)
+Release/runbook references:
+- `docs/STAGING-AND-RELEASE.md`
+- `docs/deployment.md`
+
 
 ## Environment Variables
 

--- a/docs/STAGING-AND-RELEASE.md
+++ b/docs/STAGING-AND-RELEASE.md
@@ -1,0 +1,84 @@
+# LexyAlgo site staging and release notes
+
+This repo is a static marketing shell for LexyAlgo. Treat every release as a built artifact, not a hand-edited Hostinger upload.
+
+## Build model
+
+- framework: Next.js static export
+- output mode: `output: 'export'`
+- export artifact: `out/`
+- CMS/build wrapper: TinaCMS during local build
+
+## Commands
+
+```bash
+npm install
+npm run lint
+npm run build
+```
+
+Expected result:
+- static files are produced in `out/`
+- no server-only runtime dependency is required to render the built site
+
+## Staging target
+
+Current known staging surface:
+- `https://staging.lexyalgo.com`
+
+## GitHub-driven deploy path
+
+This repo includes `.github/workflows/deploy-static-export.yml` so `main` can publish through GitHub Actions instead of drifting behind a manual Hostinger upload.
+
+### Trigger model
+
+- push to `main` -> build and deploy to the `production` GitHub environment
+- manual dispatch -> build any ref and deploy it to `staging` or `production`
+
+### Required GitHub environment secrets
+
+Create GitHub environments named `staging` and `production`, then set these secrets in each environment:
+
+- `DEPLOY_HOST` - Hostinger SSH host
+- `DEPLOY_PORT` - optional, defaults to `22`
+- `DEPLOY_USER` - SSH user for the target account
+- `DEPLOY_PATH` - remote publish directory (the confirmed docroot for that environment)
+- `DEPLOY_SSH_KEY` - private key with write access to the publish directory
+- `DEPLOY_BASE_URL` - site base URL used for post-deploy verification
+- `DEPLOY_KNOWN_HOSTS` - optional pinned host key block; if omitted the workflow falls back to `ssh-keyscan`
+
+### What the workflow proves
+
+- `npm run lint`
+- `npm run build`
+- static artifact uploaded to GitHub Actions
+- `out/build-meta.json` stamped with commit SHA and workflow metadata
+- deployed `build-meta.json` matches the exact commit GitHub built
+
+### First-time setup checklist
+
+1. confirm the exact Hostinger SSH host, user, and docroot for both staging and production
+2. add the environment secrets above in GitHub
+3. run the workflow manually against `staging`
+4. verify `https://staging.lexyalgo.com/build-meta.json` returns the expected SHA
+5. smoke-test the staging URLs listed below
+6. once staging is clean, let the `main` push path handle production deploys
+
+## Minimum smoke checklist
+
+After a staging or production push, verify:
+
+1. home page loads over HTTPS
+2. primary product sections render
+3. nav links work without routing failures
+4. blog/content pages render from the built static output
+5. waitlist or contact surfaces do not throw client errors
+6. `build-meta.json` reports the expected commit SHA
+
+## Proof to keep with each release
+
+- build command used
+- commit SHA
+- deployment workflow run URL
+- staging or production URL checked
+- whether the release is CLEAN or BLOCKED


### PR DESCRIPTION
## Summary
- add a GitHub Actions deploy workflow for the static export so `main` can publish to Hostinger through GitHub environments
- stamp each build with `build-meta.json` so staging and production can prove which SHA is live
- add a release runbook and fix the repo's lint/install drift so the workflow can actually run

## Why
Issue #27 is the current highest-leverage Lexy blocker. The contact fix in #24 is merged, but production and staging are still serving stale content because deploys can drift outside GitHub.

## What changed
- new `.github/workflows/deploy-static-export.yml`
- new `docs/STAGING-AND-RELEASE.md`
- `README.md` now points to the release runbook
- `lint` now uses `tsc --noEmit -p tsconfig.lint.json`
- `package-lock.json` refreshed so `npm ci` is back in sync with `package.json`

## Proof
- `python3` YAML parse of `.github/workflows/deploy-static-export.yml` ✅
- `npm run lint` ✅
- `npm run build` ✅

## Follow-up after merge
1. create GitHub environments named `staging` and `production`
2. add the Hostinger SSH/docroot secrets described in the runbook
3. run the workflow against staging and verify `build-meta.json`
4. once staging is clean, let `main` auto-publish production

Refs #27
