### PR TITLE
Automate Hostinger deploy for static site

### DIFF
--- a/.github/workflows/build-static-export.yml
+++ b/.github/workflows/build-static-export.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       target:

--- a/.github/workflows/build-static-export.yml
+++ b/.github/workflows/build-static-export.yml
@@ -5,6 +5,16 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      target:
+        description: "Optional deploy target"
+        required: false
+        default: none
+        type: choice
+        options:
+          - none
+          - staging
+          - production
 
 permissions:
   contents: read
@@ -12,6 +22,8 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      deploy_target: ${{ steps.resolve-target.outputs.target }}
 
     steps:
       - name: Check out repository
@@ -29,9 +41,150 @@ jobs:
       - name: Build static export
         run: npm run build
 
+      - name: Write deploy manifest
+        run: |
+          cat <<EOF > out/deploy-manifest.json
+          {
+            "gitSha": "${GITHUB_SHA}",
+            "ref": "${GITHUB_REF}",
+            "runId": "${GITHUB_RUN_ID}",
+            "runNumber": "${GITHUB_RUN_NUMBER}",
+            "builtAt": "$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+          }
+          EOF
+
+      - name: Resolve deploy target
+        id: resolve-target
+        run: |
+          target="none"
+          if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ] && [ "${{ vars.HOSTINGER_PROD_DEPLOY_ENABLED || '' }}" = "true" ]; then
+            target="production"
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            target="${{ inputs.target || 'none' }}"
+          fi
+          echo "target=$target" >> "$GITHUB_OUTPUT"
+
       - name: Upload static artifact
         uses: actions/upload-artifact@v4
         with:
           name: site-out
           path: out
           if-no-files-found: error
+
+  deploy:
+    needs: build
+    if: ${{ needs.build.outputs.deploy_target != 'none' }}
+    runs-on: ubuntu-latest
+    environment: ${{ needs.build.outputs.deploy_target }}
+
+    steps:
+      - name: Download static artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: site-out
+          path: out
+
+      - name: Resolve target configuration
+        id: config
+        env:
+          TARGET: ${{ needs.build.outputs.deploy_target }}
+          PROD_HOST: ${{ vars.HOSTINGER_PROD_HOST }}
+          PROD_PORT: ${{ vars.HOSTINGER_PROD_PORT }}
+          PROD_USER: ${{ vars.HOSTINGER_PROD_USER }}
+          PROD_PATH: ${{ vars.HOSTINGER_PROD_WEB_ROOT }}
+          PROD_URL: ${{ vars.HOSTINGER_PROD_SITE_URL }}
+          PROD_KNOWN_HOSTS: ${{ secrets.HOSTINGER_PROD_KNOWN_HOSTS }}
+          STAGING_HOST: ${{ vars.HOSTINGER_STAGING_HOST }}
+          STAGING_PORT: ${{ vars.HOSTINGER_STAGING_PORT }}
+          STAGING_USER: ${{ vars.HOSTINGER_STAGING_USER }}
+          STAGING_PATH: ${{ vars.HOSTINGER_STAGING_WEB_ROOT }}
+          STAGING_URL: ${{ vars.HOSTINGER_STAGING_SITE_URL }}
+          STAGING_KNOWN_HOSTS: ${{ secrets.HOSTINGER_STAGING_KNOWN_HOSTS }}
+        run: |
+          set -eu
+          if [ "$TARGET" = "production" ]; then
+            host="$PROD_HOST"
+            port="${PROD_PORT:-22}"
+            user="$PROD_USER"
+            path="$PROD_PATH"
+            url="$PROD_URL"
+            known_hosts="$PROD_KNOWN_HOSTS"
+          elif [ "$TARGET" = "staging" ]; then
+            host="$STAGING_HOST"
+            port="${STAGING_PORT:-22}"
+            user="$STAGING_USER"
+            path="$STAGING_PATH"
+            url="$STAGING_URL"
+            known_hosts="$STAGING_KNOWN_HOSTS"
+          else
+            echo "Unsupported target: $TARGET" >&2
+            exit 1
+          fi
+
+          for value_name in host user path url known_hosts; do
+            value=$(eval "printf '%s' \"\${$value_name}\"")
+            if [ -z "$value" ]; then
+              echo "Missing deploy configuration value: $value_name for target $TARGET" >&2
+              exit 1
+            fi
+          done
+
+          {
+            echo "host=$host"
+            echo "port=$port"
+            echo "user=$user"
+            echo "path=$path"
+            echo "url=$url"
+          } >> "$GITHUB_OUTPUT"
+
+          printf '%s\n' "$known_hosts" > "$RUNNER_TEMP/known_hosts"
+          echo "known_hosts_file=$RUNNER_TEMP/known_hosts" >> "$GITHUB_OUTPUT"
+
+      - name: Start SSH agent for production
+        if: ${{ needs.build.outputs.deploy_target == 'production' }}
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.HOSTINGER_PROD_SSH_KEY }}
+
+      - name: Start SSH agent for staging
+        if: ${{ needs.build.outputs.deploy_target == 'staging' }}
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.HOSTINGER_STAGING_SSH_KEY }}
+
+      - name: Sync static export to Hostinger
+        env:
+          DEPLOY_HOST: ${{ steps.config.outputs.host }}
+          DEPLOY_PORT: ${{ steps.config.outputs.port }}
+          DEPLOY_USER: ${{ steps.config.outputs.user }}
+          DEPLOY_PATH: ${{ steps.config.outputs.path }}
+          KNOWN_HOSTS_FILE: ${{ steps.config.outputs.known_hosts_file }}
+        run: |
+          rsync -az --delete \
+            -e "ssh -p $DEPLOY_PORT -o StrictHostKeyChecking=yes -o UserKnownHostsFile=$KNOWN_HOSTS_FILE" \
+            out/ "$DEPLOY_USER@$DEPLOY_HOST:$DEPLOY_PATH/"
+
+      - name: Verify deployed manifest
+        env:
+          SITE_URL: ${{ steps.config.outputs.url }}
+        run: |
+          curl --fail --silent --show-error "$SITE_URL/deploy-manifest.json" -o deploy-manifest.json
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          manifest = json.loads(Path('deploy-manifest.json').read_text())
+          expected = "${{ github.sha }}"
+          actual = manifest.get('gitSha')
+          if actual != expected:
+              raise SystemExit(f"deployed gitSha {actual!r} did not match expected {expected!r}")
+          print(f"Verified deployed gitSha: {actual}")
+          PY
+
+      - name: Smoke-test public routes
+        env:
+          SITE_URL: ${{ steps.config.outputs.url }}
+        run: |
+          for route in / /pricing /terms /privacy /contact /contact/thanks; do
+            curl --fail --silent --show-error --location "$SITE_URL$route" > /dev/null
+          done

--- a/README.md
+++ b/README.md
@@ -43,15 +43,14 @@ Static output goes to `/out/`.
 
 ## Deployment
 
-This repo builds to a static export and now includes a GitHub Actions deploy workflow for Hostinger-backed staging and production releases.
+This repo builds to a static export and can deploy it to Hostinger directly from GitHub Actions.
 
-- Pushes to `main` build, lint, stamp `out/build-meta.json`, and deploy through the `production` GitHub environment.
-- Manual workflow dispatch can deploy any ref to `staging` or `production` once environment secrets are configured.
-- The deployable build artifact is the `static-export` Actions artifact, containing the contents of `/out/`.
+- Every push to `main` builds a deployable `site-out` artifact.
+- The artifact includes `deploy-manifest.json` so the workflow can verify the live site is serving the expected Git SHA.
+- Manual workflow runs can stay build-only or deploy to `staging` / `production`.
+- Automatic production deploys are gated by repo configuration so `main` does not drift once Hostinger variables and secrets are set.
 
-Release/runbook references:
-- `docs/STAGING-AND-RELEASE.md`
-- `docs/deployment.md`
+Detailed runbook: [`docs/deployment.md`](docs/deployment.md)
 
 
 ## Environment Variables

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -6,7 +6,7 @@ Known production proof from issue tracking:
 
 - `lexyalgo.com` is serving through nginx on a Hostinger-hosted server.
 - The site is a static Next.js export.
-- This repository is the source of truth for the build, but production publishing has been happening outside the repo.
+- This repository is the source of truth for the build and now also carries the deploy workflow for Hostinger.
 
 ## Build artifact
 
@@ -19,23 +19,70 @@ npm run build
 
 GitHub Actions publishes this directory as an artifact named `site-out` on every push to `main` and on manual runs.
 
-## Release procedure
+Each artifact also includes `deploy-manifest.json`, which records the Git SHA, ref, workflow run, and build timestamp. The deploy workflow verifies that the live site is serving the same SHA before marking the run successful.
 
-1. Open the latest successful **Build static export** workflow run for `main`.
-2. Download the `site-out` artifact.
-3. Extract the artifact locally.
-4. Sync the extracted files to the nginx web root that serves `lexyalgo.com`.
-5. Verify the live site matches current `main`.
+## GitHub Actions deployment flow
 
-## Suggested host-side sync commands
+Workflow: `.github/workflows/build-static-export.yml`
 
-Adjust paths/usernames to match the actual Hostinger setup.
+### Automatic production deploy
+
+On every push to `main`, the workflow will:
+
+1. build the static export
+2. upload the `site-out` artifact
+3. deploy to production via `rsync` over SSH, if production deploy has been enabled in repo variables
+4. verify `https://lexyalgo.com/deploy-manifest.json` matches the pushed commit SHA
+5. smoke-test `/`, `/pricing`, `/terms`, `/privacy`, `/contact`, and `/contact/thanks`
+
+### Manual deploy
+
+You can also run the workflow manually and pick one of:
+
+- `none` for build-only
+- `staging` to deploy to the staging Hostinger target
+- `production` to redeploy production from the selected commit
+
+## Required GitHub configuration
+
+### Production repository variables
+
+- `HOSTINGER_PROD_DEPLOY_ENABLED=true`
+- `HOSTINGER_PROD_HOST`
+- `HOSTINGER_PROD_PORT` (optional, defaults to `22`)
+- `HOSTINGER_PROD_USER`
+- `HOSTINGER_PROD_WEB_ROOT`
+- `HOSTINGER_PROD_SITE_URL` (for example `https://lexyalgo.com`)
+
+### Production repository secrets
+
+- `HOSTINGER_PROD_SSH_KEY`
+- `HOSTINGER_PROD_KNOWN_HOSTS`
+
+### Staging repository variables
+
+- `HOSTINGER_STAGING_HOST`
+- `HOSTINGER_STAGING_PORT` (optional, defaults to `22`)
+- `HOSTINGER_STAGING_USER`
+- `HOSTINGER_STAGING_WEB_ROOT`
+- `HOSTINGER_STAGING_SITE_URL` (for example `https://staging.lexyalgo.com`)
+
+### Staging repository secrets
+
+- `HOSTINGER_STAGING_SSH_KEY`
+- `HOSTINGER_STAGING_KNOWN_HOSTS`
+
+`HOSTINGER_*_KNOWN_HOSTS` should contain the exact `known_hosts` line for the target box, not a runtime `ssh-keyscan`, so workflow verification stays strict.
+
+## Host path expectations
+
+The workflow syncs the contents of `out/` directly into the configured nginx web root:
 
 ```bash
-rsync -av --delete ./out/ user@host:/var/www/lexyalgo.com/
+rsync -az --delete ./out/ user@host:/var/www/lexyalgo.com/
 ```
 
-If the artifact is downloaded as a zip/tar bundle, extract it first, then sync the exported files.
+Set `HOSTINGER_*_WEB_ROOT` to the directory nginx already serves for that hostname.
 
 ## Contact form activation
 
@@ -61,6 +108,7 @@ After deploy, verify at least:
 - `/privacy`
 - `/contact`
 - `/contact/thanks`
+- `/deploy-manifest.json`
 
 Recommended proof commands:
 
@@ -70,16 +118,7 @@ curl -I https://lexyalgo.com/pricing
 curl -I https://lexyalgo.com/terms
 curl -I https://lexyalgo.com/privacy
 curl -I https://lexyalgo.com/contact
+curl https://lexyalgo.com/deploy-manifest.json
 ```
 
-Capture the workflow run URL, artifact run SHA, and verification output in the linked issue or PR.
-
-## Follow-up automation options
-
-Once Hostinger access is confirmed, upgrade this from build-only to full deployment by choosing one of:
-
-1. GitHub Actions + SSH/rsync to the Hostinger box
-2. GitHub Actions + SCP upload + atomic symlink switch on host
-3. Move hosting to a repo-connected static platform if operationally simpler
-
-Until host credentials and target paths are confirmed, this repo intentionally stops at producing a proof-backed deployable artifact.
+Capture the workflow run URL, deployed SHA, and verification output in the linked issue or PR.


### PR DESCRIPTION
## Summary
- extend the static export workflow so it can build, stamp, and deploy the site from GitHub Actions
- add strict Hostinger SSH/known_hosts configuration plus live manifest verification and route smoke tests
- document the repo vars and secrets needed to enable staging and production deploys

## Proof
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build-static-export.yml"); puts "workflow yaml ok"'
- npm run lint
- npm run build

Refs #27
