### PR TITLE
fix: remove stale static deploy path

### DIFF
--- a/.github/workflows/build-static-export.yml
+++ b/.github/workflows/build-static-export.yml
@@ -8,16 +8,6 @@ on:
     branches:
       - main
   workflow_dispatch:
-    inputs:
-      target:
-        description: "Optional deploy target"
-        required: false
-        default: none
-        type: choice
-        options:
-          - none
-          - staging
-          - production
 
 permissions:
   contents: read
@@ -25,8 +15,6 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    outputs:
-      deploy_target: ${{ steps.resolve-target.outputs.target }}
 
     steps:
       - name: Check out repository
@@ -41,153 +29,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Lint
+        run: npm run lint
+
       - name: Build static export
         run: npm run build
-
-      - name: Write deploy manifest
-        run: |
-          cat <<EOF > out/deploy-manifest.json
-          {
-            "gitSha": "${GITHUB_SHA}",
-            "ref": "${GITHUB_REF}",
-            "runId": "${GITHUB_RUN_ID}",
-            "runNumber": "${GITHUB_RUN_NUMBER}",
-            "builtAt": "$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
-          }
-          EOF
-
-      - name: Resolve deploy target
-        id: resolve-target
-        run: |
-          target="none"
-          if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ] && [ "${{ vars.HOSTINGER_PROD_DEPLOY_ENABLED || '' }}" = "true" ]; then
-            target="production"
-          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            target="${{ inputs.target || 'none' }}"
-          fi
-          echo "target=$target" >> "$GITHUB_OUTPUT"
-
-      - name: Upload static artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: site-out
-          path: out
-          if-no-files-found: error
-
-  deploy:
-    needs: build
-    if: ${{ needs.build.outputs.deploy_target != 'none' }}
-    runs-on: ubuntu-latest
-    environment: ${{ needs.build.outputs.deploy_target }}
-
-    steps:
-      - name: Download static artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: site-out
-          path: out
-
-      - name: Resolve target configuration
-        id: config
-        env:
-          TARGET: ${{ needs.build.outputs.deploy_target }}
-          PROD_HOST: ${{ vars.HOSTINGER_PROD_HOST }}
-          PROD_PORT: ${{ vars.HOSTINGER_PROD_PORT }}
-          PROD_USER: ${{ vars.HOSTINGER_PROD_USER }}
-          PROD_PATH: ${{ vars.HOSTINGER_PROD_WEB_ROOT }}
-          PROD_URL: ${{ vars.HOSTINGER_PROD_SITE_URL }}
-          PROD_KNOWN_HOSTS: ${{ secrets.HOSTINGER_PROD_KNOWN_HOSTS }}
-          STAGING_HOST: ${{ vars.HOSTINGER_STAGING_HOST }}
-          STAGING_PORT: ${{ vars.HOSTINGER_STAGING_PORT }}
-          STAGING_USER: ${{ vars.HOSTINGER_STAGING_USER }}
-          STAGING_PATH: ${{ vars.HOSTINGER_STAGING_WEB_ROOT }}
-          STAGING_URL: ${{ vars.HOSTINGER_STAGING_SITE_URL }}
-          STAGING_KNOWN_HOSTS: ${{ secrets.HOSTINGER_STAGING_KNOWN_HOSTS }}
-        run: |
-          set -eu
-          if [ "$TARGET" = "production" ]; then
-            host="$PROD_HOST"
-            port="${PROD_PORT:-22}"
-            user="$PROD_USER"
-            path="$PROD_PATH"
-            url="$PROD_URL"
-            known_hosts="$PROD_KNOWN_HOSTS"
-          elif [ "$TARGET" = "staging" ]; then
-            host="$STAGING_HOST"
-            port="${STAGING_PORT:-22}"
-            user="$STAGING_USER"
-            path="$STAGING_PATH"
-            url="$STAGING_URL"
-            known_hosts="$STAGING_KNOWN_HOSTS"
-          else
-            echo "Unsupported target: $TARGET" >&2
-            exit 1
-          fi
-
-          for value_name in host user path url known_hosts; do
-            value=$(eval "printf '%s' \"\${$value_name}\"")
-            if [ -z "$value" ]; then
-              echo "Missing deploy configuration value: $value_name for target $TARGET" >&2
-              exit 1
-            fi
-          done
-
-          {
-            echo "host=$host"
-            echo "port=$port"
-            echo "user=$user"
-            echo "path=$path"
-            echo "url=$url"
-          } >> "$GITHUB_OUTPUT"
-
-          printf '%s\n' "$known_hosts" > "$RUNNER_TEMP/known_hosts"
-          echo "known_hosts_file=$RUNNER_TEMP/known_hosts" >> "$GITHUB_OUTPUT"
-
-      - name: Start SSH agent for production
-        if: ${{ needs.build.outputs.deploy_target == 'production' }}
-        uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.HOSTINGER_PROD_SSH_KEY }}
-
-      - name: Start SSH agent for staging
-        if: ${{ needs.build.outputs.deploy_target == 'staging' }}
-        uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.HOSTINGER_STAGING_SSH_KEY }}
-
-      - name: Sync static export to Hostinger
-        env:
-          DEPLOY_HOST: ${{ steps.config.outputs.host }}
-          DEPLOY_PORT: ${{ steps.config.outputs.port }}
-          DEPLOY_USER: ${{ steps.config.outputs.user }}
-          DEPLOY_PATH: ${{ steps.config.outputs.path }}
-          KNOWN_HOSTS_FILE: ${{ steps.config.outputs.known_hosts_file }}
-        run: |
-          rsync -az --delete \
-            -e "ssh -p $DEPLOY_PORT -o StrictHostKeyChecking=yes -o UserKnownHostsFile=$KNOWN_HOSTS_FILE" \
-            out/ "$DEPLOY_USER@$DEPLOY_HOST:$DEPLOY_PATH/"
-
-      - name: Verify deployed manifest
-        env:
-          SITE_URL: ${{ steps.config.outputs.url }}
-        run: |
-          curl --fail --silent --show-error "$SITE_URL/deploy-manifest.json" -o deploy-manifest.json
-          python - <<'PY'
-          import json
-          from pathlib import Path
-
-          manifest = json.loads(Path('deploy-manifest.json').read_text())
-          expected = "${{ github.sha }}"
-          actual = manifest.get('gitSha')
-          if actual != expected:
-              raise SystemExit(f"deployed gitSha {actual!r} did not match expected {expected!r}")
-          print(f"Verified deployed gitSha: {actual}")
-          PY
-
-      - name: Smoke-test public routes
-        env:
-          SITE_URL: ${{ steps.config.outputs.url }}
-        run: |
-          for route in / /pricing /terms /privacy /contact /contact/thanks; do
-            curl --fail --silent --show-error --location "$SITE_URL$route" > /dev/null
-          done

--- a/README.md
+++ b/README.md
@@ -45,12 +45,14 @@ Static output goes to `/out/`.
 
 This repo builds to a static export and can deploy it to Hostinger directly from GitHub Actions.
 
-- Every push to `main` builds a deployable `site-out` artifact.
-- The artifact includes `deploy-manifest.json` so the workflow can verify the live site is serving the expected Git SHA.
-- Manual workflow runs can stay build-only or deploy to `staging` / `production`.
-- Automatic production deploys are gated by repo configuration so `main` does not drift once Hostinger variables and secrets are set.
+- `Build static export` runs on push/PR and produces a deployable static artifact.
+- `Deploy static export` builds, deploys, and verifies against the selected GitHub environment.
+- The deployed artifact includes `build-meta.json` so the workflow can verify the live site is serving the expected Git SHA.
+- Manual workflow runs can target `staging` or `production`.
+- Pushes to `main` target the `production` environment automatically.
 
 Detailed runbook: [`docs/deployment.md`](docs/deployment.md)
+Environment bootstrap: [`docs/github-environment-bootstrap.md`](docs/github-environment-bootstrap.md)
 
 
 ## Environment Variables

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -17,72 +17,68 @@ npm ci
 npm run build
 ```
 
-GitHub Actions publishes this directory as an artifact named `site-out` on every push to `main` and on manual runs.
+GitHub Actions publishes this directory as the `static-export` artifact in `.github/workflows/deploy-static-export.yml`.
 
-Each artifact also includes `deploy-manifest.json`, which records the Git SHA, ref, workflow run, and build timestamp. The deploy workflow verifies that the live site is serving the same SHA before marking the run successful.
+Each deploy also stamps `out/build-meta.json`, which records the environment, Git SHA, workflow run, and build timestamp. The deploy workflow uses that file for post-deploy verification.
 
 ## GitHub Actions deployment flow
 
-Workflow: `.github/workflows/build-static-export.yml`
+Primary deploy workflow: `.github/workflows/deploy-static-export.yml`
+
+Related CI workflow: `.github/workflows/build-static-export.yml`
 
 ### Automatic production deploy
 
-On every push to `main`, the workflow will:
+On every push to `main`, `Deploy static export` will:
 
-1. build the static export
-2. upload the `site-out` artifact
-3. deploy to production via `rsync` over SSH, if production deploy has been enabled in repo variables
-4. verify `https://lexyalgo.com/deploy-manifest.json` matches the pushed commit SHA
-5. smoke-test `/`, `/pricing`, `/terms`, `/privacy`, `/contact`, and `/contact/thanks`
+1. resolve the deploy target to `production`
+2. build the static export
+3. upload the `static-export` artifact
+4. deploy to production via `rsync` over SSH
+5. verify `https://lexyalgo.com/build-meta.json` matches the built SHA, if `DEPLOY_BASE_URL` is configured for the environment
 
 ### Manual deploy
 
-You can also run the workflow manually and pick one of:
+You can also run `Deploy static export` manually and choose:
 
-- `none` for build-only
-- `staging` to deploy to the staging Hostinger target
-- `production` to redeploy production from the selected commit
+- `staging`
+- `production`
+
+You can also choose the ref to build and deploy.
 
 ## Required GitHub configuration
 
-### Production repository variables
+The deploy workflow reads from **GitHub environment secrets**, not repo-level variables.
 
-- `HOSTINGER_PROD_DEPLOY_ENABLED=true`
-- `HOSTINGER_PROD_HOST`
-- `HOSTINGER_PROD_PORT` (optional, defaults to `22`)
-- `HOSTINGER_PROD_USER`
-- `HOSTINGER_PROD_WEB_ROOT`
-- `HOSTINGER_PROD_SITE_URL` (for example `https://lexyalgo.com`)
+Environment names:
 
-### Production repository secrets
+- `staging`
+- `production`
 
-- `HOSTINGER_PROD_SSH_KEY`
-- `HOSTINGER_PROD_KNOWN_HOSTS`
+### Required secrets for each environment
 
-### Staging repository variables
+- `DEPLOY_HOST`
+- `DEPLOY_USER`
+- `DEPLOY_PATH`
+- `DEPLOY_SSH_KEY`
 
-- `HOSTINGER_STAGING_HOST`
-- `HOSTINGER_STAGING_PORT` (optional, defaults to `22`)
-- `HOSTINGER_STAGING_USER`
-- `HOSTINGER_STAGING_WEB_ROOT`
-- `HOSTINGER_STAGING_SITE_URL` (for example `https://staging.lexyalgo.com`)
+### Optional but recommended secrets for each environment
 
-### Staging repository secrets
+- `DEPLOY_PORT` (defaults to `22`)
+- `DEPLOY_KNOWN_HOSTS`
+- `DEPLOY_BASE_URL`
 
-- `HOSTINGER_STAGING_SSH_KEY`
-- `HOSTINGER_STAGING_KNOWN_HOSTS`
-
-`HOSTINGER_*_KNOWN_HOSTS` should contain the exact `known_hosts` line for the target box, not a runtime `ssh-keyscan`, so workflow verification stays strict.
+See [`docs/github-environment-bootstrap.md`](./github-environment-bootstrap.md) for the exact bootstrap checklist.
 
 ## Host path expectations
 
-The workflow syncs the contents of `out/` directly into the configured nginx web root:
+The workflow syncs the contents of `out/` directly into the configured web root:
 
 ```bash
 rsync -az --delete ./out/ user@host:/var/www/lexyalgo.com/
 ```
 
-Set `HOSTINGER_*_WEB_ROOT` to the directory nginx already serves for that hostname.
+Set `DEPLOY_PATH` to the directory nginx already serves for that hostname.
 
 ## Contact form activation
 
@@ -108,7 +104,7 @@ After deploy, verify at least:
 - `/privacy`
 - `/contact`
 - `/contact/thanks`
-- `/deploy-manifest.json`
+- `/build-meta.json`
 
 Recommended proof commands:
 
@@ -118,7 +114,7 @@ curl -I https://lexyalgo.com/pricing
 curl -I https://lexyalgo.com/terms
 curl -I https://lexyalgo.com/privacy
 curl -I https://lexyalgo.com/contact
-curl https://lexyalgo.com/deploy-manifest.json
+curl https://lexyalgo.com/build-meta.json
 ```
 
 Capture the workflow run URL, deployed SHA, and verification output in the linked issue or PR.

--- a/docs/github-environment-bootstrap.md
+++ b/docs/github-environment-bootstrap.md
@@ -1,0 +1,65 @@
+# GitHub environment bootstrap for static deploys
+
+Use this when wiring the `staging` and `production` GitHub environments for `.github/workflows/deploy-static-export.yml`.
+
+## Environment names
+
+Create or reuse exactly these two GitHub environments:
+
+- `staging`
+- `production`
+
+## Required environment secrets
+
+Set these secrets on **each** environment:
+
+- `DEPLOY_HOST`
+- `DEPLOY_USER`
+- `DEPLOY_PATH`
+- `DEPLOY_SSH_KEY`
+
+## Optional environment secrets
+
+- `DEPLOY_PORT` (defaults to `22`)
+- `DEPLOY_KNOWN_HOSTS` (recommended, otherwise the workflow falls back to `ssh-keyscan`)
+- `DEPLOY_BASE_URL` (recommended, enables post-deploy `build-meta.json` verification)
+
+## What each value should contain
+
+- `DEPLOY_HOST`: SSH host or IP for the Hostinger target
+- `DEPLOY_USER`: SSH username
+- `DEPLOY_PATH`: nginx web root for the static site on that host
+- `DEPLOY_SSH_KEY`: private key allowed to write to `DEPLOY_PATH`
+- `DEPLOY_PORT`: SSH port if not `22`
+- `DEPLOY_KNOWN_HOSTS`: exact `known_hosts` line for the target host
+- `DEPLOY_BASE_URL`: public base URL, for example `https://staging.lexyalgo.com` or `https://lexyalgo.com`
+
+## UI checklist
+
+For each environment:
+
+1. Open `Settings` → `Environments`
+2. Select `staging` or `production`
+3. Add the required secrets above
+4. Save `DEPLOY_BASE_URL` so the workflow can verify `/build-meta.json`
+5. Rerun `Deploy static export`
+
+## Verification targets
+
+After wiring `staging`:
+
+1. Run `Deploy static export` with `environment=staging`
+2. Confirm the workflow succeeds
+3. Confirm `https://staging.lexyalgo.com/build-meta.json` reports the run SHA
+
+After wiring `production`:
+
+1. Push or rerun against `main`
+2. Confirm the workflow succeeds in the `production` environment
+3. Confirm `https://lexyalgo.com/build-meta.json` reports the deployed SHA
+
+## Quick operator note
+
+The workflow currently reads **environment secrets**, not repository-level vars, for the deploy connection values. If the environment exists but these secret names are empty, the run will fail early with:
+
+`Missing DEPLOY_HOST or DEPLOY_SSH_KEY for environment <name>`


### PR DESCRIPTION
## Summary
- remove the stale Hostinger deploy path from `.github/workflows/build-static-export.yml` so `.github/workflows/deploy-static-export.yml` is the only deploy workflow
- update deployment docs to match the live `DEPLOY_*` environment-secret contract
- add a bootstrap checklist for wiring the `staging` and `production` GitHub environments

## Why
Issue #30 was blocked not only by missing environment secrets, but also by repo drift: the repo still carried a second, outdated deploy flow using old `HOSTINGER_*` names and `deploy-manifest.json`. That made the deploy contract ambiguous.

## Verification
- `npm ci`
- `npm run lint`
- `npm run build`

Refs #30
