### PR TITLE
chore: accept env vars in static deploy wiring

### DIFF
--- a/.github/workflows/deploy-static-export.yml
+++ b/.github/workflows/deploy-static-export.yml
@@ -129,14 +129,14 @@ jobs:
 
       - name: Configure SSH access
         env:
-          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
-          DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
-          DEPLOY_KNOWN_HOSTS: ${{ secrets.DEPLOY_KNOWN_HOSTS }}
+          DEPLOY_HOST: ${{ vars.DEPLOY_HOST != '' && vars.DEPLOY_HOST || secrets.DEPLOY_HOST }}
+          DEPLOY_PORT: ${{ vars.DEPLOY_PORT != '' && vars.DEPLOY_PORT || secrets.DEPLOY_PORT }}
+          DEPLOY_KNOWN_HOSTS: ${{ vars.DEPLOY_KNOWN_HOSTS != '' && vars.DEPLOY_KNOWN_HOSTS || secrets.DEPLOY_KNOWN_HOSTS }}
           DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
         shell: bash
         run: |
           if [ -z "$DEPLOY_HOST" ] || [ -z "$DEPLOY_SSH_KEY" ]; then
-            echo "Missing DEPLOY_HOST or DEPLOY_SSH_KEY for environment ${{ needs.build.outputs.deploy_environment }}" >&2
+            echo "Missing DEPLOY_HOST (env var or secret) or DEPLOY_SSH_KEY (secret) for environment ${{ needs.build.outputs.deploy_environment }}" >&2
             exit 1
           fi
 
@@ -156,14 +156,14 @@ jobs:
 
       - name: Sync artifact to Hostinger
         env:
-          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
-          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
-          DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
-          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_HOST: ${{ vars.DEPLOY_HOST != '' && vars.DEPLOY_HOST || secrets.DEPLOY_HOST }}
+          DEPLOY_PATH: ${{ vars.DEPLOY_PATH != '' && vars.DEPLOY_PATH || secrets.DEPLOY_PATH }}
+          DEPLOY_PORT: ${{ vars.DEPLOY_PORT != '' && vars.DEPLOY_PORT || secrets.DEPLOY_PORT }}
+          DEPLOY_USER: ${{ vars.DEPLOY_USER != '' && vars.DEPLOY_USER || secrets.DEPLOY_USER }}
         shell: bash
         run: |
           if [ -z "$DEPLOY_HOST" ] || [ -z "$DEPLOY_USER" ] || [ -z "$DEPLOY_PATH" ]; then
-            echo "Missing one of DEPLOY_HOST, DEPLOY_USER, or DEPLOY_PATH" >&2
+            echo "Missing one of DEPLOY_HOST, DEPLOY_USER, or DEPLOY_PATH (env vars or secrets)" >&2
             exit 1
           fi
 
@@ -180,7 +180,7 @@ jobs:
 
       - name: Verify deployed build metadata
         env:
-          DEPLOY_BASE_URL: ${{ secrets.DEPLOY_BASE_URL }}
+          DEPLOY_BASE_URL: ${{ vars.DEPLOY_BASE_URL != '' && vars.DEPLOY_BASE_URL || secrets.DEPLOY_BASE_URL }}
           EXPECTED_SHA: ${{ needs.build.outputs.deploy_sha }}
         shell: bash
         run: |

--- a/docs/STAGING-AND-RELEASE.md
+++ b/docs/STAGING-AND-RELEASE.md
@@ -35,17 +35,26 @@ This repo includes `.github/workflows/deploy-static-export.yml` so `main` can pu
 - push to `main` -> build and deploy to the `production` GitHub environment
 - manual dispatch -> build any ref and deploy it to `staging` or `production`
 
-### Required GitHub environment secrets
+### Required GitHub environment configuration
 
-Create GitHub environments named `staging` and `production`, then set these secrets in each environment:
+Create GitHub environments named `staging` and `production`.
 
+Recommended split:
+
+Environment variables:
 - `DEPLOY_HOST` - Hostinger SSH host
 - `DEPLOY_PORT` - optional, defaults to `22`
 - `DEPLOY_USER` - SSH user for the target account
 - `DEPLOY_PATH` - remote publish directory (the confirmed docroot for that environment)
-- `DEPLOY_SSH_KEY` - private key with write access to the publish directory
 - `DEPLOY_BASE_URL` - site base URL used for post-deploy verification
 - `DEPLOY_KNOWN_HOSTS` - optional pinned host key block; if omitted the workflow falls back to `ssh-keyscan`
+
+Environment secret:
+- `DEPLOY_SSH_KEY` - private key with write access to the publish directory
+
+Compatibility note:
+- the workflow accepts `DEPLOY_HOST`, `DEPLOY_PORT`, `DEPLOY_USER`, `DEPLOY_PATH`, `DEPLOY_BASE_URL`, and `DEPLOY_KNOWN_HOSTS` from either environment variables or secrets
+- `DEPLOY_SSH_KEY` must remain a secret
 
 ### What the workflow proves
 
@@ -58,7 +67,7 @@ Create GitHub environments named `staging` and `production`, then set these secr
 ### First-time setup checklist
 
 1. confirm the exact Hostinger SSH host, user, and docroot for both staging and production
-2. add the environment secrets above in GitHub
+2. add the environment variables and `DEPLOY_SSH_KEY` secret above in GitHub
 3. run the workflow manually against `staging`
 4. verify `https://staging.lexyalgo.com/build-meta.json` returns the expected SHA
 5. smoke-test the staging URLs listed below

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -48,22 +48,26 @@ You can also choose the ref to build and deploy.
 
 ## Required GitHub configuration
 
-The deploy workflow reads from **GitHub environment secrets**, not repo-level variables.
+The deploy workflow accepts the non-sensitive deploy values from **GitHub environment variables or environment secrets**. `DEPLOY_SSH_KEY` must remain an environment secret.
 
 Environment names:
 
 - `staging`
 - `production`
 
-### Required secrets for each environment
+### Required configuration for each environment
 
+Environment variables:
 - `DEPLOY_HOST`
 - `DEPLOY_USER`
 - `DEPLOY_PATH`
+
+Environment secret:
 - `DEPLOY_SSH_KEY`
 
-### Optional but recommended secrets for each environment
+### Optional but recommended configuration for each environment
 
+Environment variables or secrets:
 - `DEPLOY_PORT` (defaults to `22`)
 - `DEPLOY_KNOWN_HOSTS`
 - `DEPLOY_BASE_URL`

--- a/docs/github-environment-bootstrap.md
+++ b/docs/github-environment-bootstrap.md
@@ -9,17 +9,21 @@ Create or reuse exactly these two GitHub environments:
 - `staging`
 - `production`
 
-## Required environment secrets
+## Required environment configuration
 
-Set these secrets on **each** environment:
+Set these values on **each** environment.
 
+Environment variables:
 - `DEPLOY_HOST`
 - `DEPLOY_USER`
 - `DEPLOY_PATH`
+
+Environment secret:
 - `DEPLOY_SSH_KEY`
 
-## Optional environment secrets
+## Optional environment configuration
 
+Environment variables or secrets:
 - `DEPLOY_PORT` (defaults to `22`)
 - `DEPLOY_KNOWN_HOSTS` (recommended, otherwise the workflow falls back to `ssh-keyscan`)
 - `DEPLOY_BASE_URL` (recommended, enables post-deploy `build-meta.json` verification)
@@ -40,7 +44,7 @@ For each environment:
 
 1. Open `Settings` → `Environments`
 2. Select `staging` or `production`
-3. Add the required secrets above
+3. Add the required environment variables and `DEPLOY_SSH_KEY` secret above
 4. Save `DEPLOY_BASE_URL` so the workflow can verify `/build-meta.json`
 5. Rerun `Deploy static export`
 
@@ -60,6 +64,6 @@ After wiring `production`:
 
 ## Quick operator note
 
-The workflow currently reads **environment secrets**, not repository-level vars, for the deploy connection values. If the environment exists but these secret names are empty, the run will fail early with:
+The workflow now accepts the non-sensitive deploy connection values from **environment variables or environment secrets**. `DEPLOY_SSH_KEY` must still be stored as an environment secret. If the environment exists but `DEPLOY_HOST` or `DEPLOY_SSH_KEY` is missing, the run will still fail early with:
 
-`Missing DEPLOY_HOST or DEPLOY_SSH_KEY for environment <name>`
+`Missing DEPLOY_HOST (env var or secret) or DEPLOY_SSH_KEY (secret) for environment <name>`


### PR DESCRIPTION
## Summary
- let the deploy workflow read non-sensitive `DEPLOY_*` values from GitHub environment vars with secret fallback
- keep `DEPLOY_SSH_KEY` secret-only
- update deploy docs and bootstrap notes to match the new contract

## Why
Issue #30 is currently blocked on empty GitHub environments. This change shrinks the required secret surface and makes the environment setup path clearer, while staying compatible with secret-based wiring.

## Testing
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-static-export.yml"); puts "yaml-ok"'`
- `git diff --check`

Closes #30 after the staging/production environment values are populated and the workflow is rerun successfully.
