### PR TITLE
fix: deploy static export into live containers

### DIFF
--- a/.github/workflows/deploy-static-export.yml
+++ b/.github/workflows/deploy-static-export.yml
@@ -202,25 +202,52 @@ jobs:
           DEPLOY_PORT: ${{ vars.DEPLOY_PORT != '' && vars.DEPLOY_PORT || secrets.DEPLOY_PORT }}
           DEPLOY_USER: ${{ vars.DEPLOY_USER != '' && vars.DEPLOY_USER || secrets.DEPLOY_USER }}
           REMOTE_STAGE_DIR: /tmp/lexyalgo-static-export-${{ github.run_id }}-${{ github.run_attempt }}
+          RUN_SUFFIX: ${{ github.run_id }}-${{ github.run_attempt }}
         shell: bash
         run: |
           port="$DEPLOY_PORT"
           [ -n "$port" ] || port=22
 
           if [ -n "$DEPLOY_CONTAINER" ]; then
-            ssh -i ~/.ssh/id_ed25519 -p "$port" "$DEPLOY_USER@$DEPLOY_HOST" \
-              "set -e; \
-              docker inspect '$DEPLOY_CONTAINER' >/dev/null; \
-              docker exec '$DEPLOY_CONTAINER' sh -lc 'mkdir -p '\''$DEPLOY_CONTAINER_PATH'\''' ; \
-              tar -C '$REMOTE_STAGE_DIR' -cf - . | docker exec -i '$DEPLOY_CONTAINER' sh -lc 'rm -rf '\''$DEPLOY_CONTAINER_PATH'\''/* '\''$DEPLOY_CONTAINER_PATH'\''/.[!.]* '\''$DEPLOY_CONTAINER_PATH'\''/..?* 2>/dev/null || true; mkdir -p '\''$DEPLOY_CONTAINER_PATH'\''; tar -xf - -C '\''$DEPLOY_CONTAINER_PATH'\''' ; \
-              rm -rf '$REMOTE_STAGE_DIR'"
+            ssh -i ~/.ssh/id_ed25519 -p "$port" "$DEPLOY_USER@$DEPLOY_HOST" /bin/sh <<EOF
+          set -e
+          docker inspect '$DEPLOY_CONTAINER' >/dev/null
+          target='$DEPLOY_CONTAINER_PATH'
+          parent=\$(dirname "\$target")
+          base=\$(basename "\$target")
+          incoming="\$parent/.\$base.incoming-$RUN_SUFFIX"
+          backup="\$parent/.\$base.previous-$RUN_SUFFIX"
+          docker exec -e TARGET_PATH="\$target" -e INCOMING_PATH="\$incoming" -e BACKUP_PATH="\$backup" '$DEPLOY_CONTAINER' sh -lc '
+            set -e
+            mkdir -p "\$(dirname "$TARGET_PATH")"
+            rm -rf "$INCOMING_PATH" "$BACKUP_PATH"
+            mkdir -p "$INCOMING_PATH"
+          '
+          tar -C '$REMOTE_STAGE_DIR' -cf - . | docker exec -i -e INCOMING_PATH="\$incoming" '$DEPLOY_CONTAINER' sh -lc 'set -e; tar -xf - -C "$INCOMING_PATH"'
+          docker exec -e TARGET_PATH="\$target" -e INCOMING_PATH="\$incoming" -e BACKUP_PATH="\$backup" '$DEPLOY_CONTAINER' sh -lc '
+            set -e
+            if [ -e "$TARGET_PATH" ]; then mv "$TARGET_PATH" "$BACKUP_PATH"; fi
+            mv "$INCOMING_PATH" "$TARGET_PATH"
+            rm -rf "$BACKUP_PATH"
+          '
+          rm -rf '$REMOTE_STAGE_DIR'
+          EOF
           else
-            ssh -i ~/.ssh/id_ed25519 -p "$port" "$DEPLOY_USER@$DEPLOY_HOST" \
-              "set -e; \
-              mkdir -p '$DEPLOY_PATH'; \
-              rm -rf '$DEPLOY_PATH'/* '$DEPLOY_PATH'/.[!.]* '$DEPLOY_PATH'/..?* 2>/dev/null || true; \
-              tar -C '$REMOTE_STAGE_DIR' -cf - . | tar -xf - -C '$DEPLOY_PATH'; \
-              rm -rf '$REMOTE_STAGE_DIR'"
+            ssh -i ~/.ssh/id_ed25519 -p "$port" "$DEPLOY_USER@$DEPLOY_HOST" /bin/sh <<EOF
+          set -e
+          target='$DEPLOY_PATH'
+          parent=\$(dirname "\$target")
+          base=\$(basename "\$target")
+          incoming="\$parent/.\$base.incoming-$RUN_SUFFIX"
+          backup="\$parent/.\$base.previous-$RUN_SUFFIX"
+          mkdir -p "\$parent"
+          rm -rf "\$incoming" "\$backup"
+          mkdir -p "\$incoming"
+          tar -C '$REMOTE_STAGE_DIR' -cf - . | tar -xf - -C "\$incoming"
+          if [ -e "\$target" ]; then mv "\$target" "\$backup"; fi
+          mv "\$incoming" "\$target"
+          rm -rf "\$backup" '$REMOTE_STAGE_DIR'
+          EOF
           fi
 
       - name: Verify deployed build metadata

--- a/.github/workflows/deploy-static-export.yml
+++ b/.github/workflows/deploy-static-export.yml
@@ -154,21 +154,36 @@ jobs:
           fi
           chmod 644 ~/.ssh/known_hosts
 
-      - name: Sync artifact to Hostinger
+      - name: Stage artifact on Hostinger
         env:
+          DEPLOY_CONTAINER: ${{ vars.DEPLOY_CONTAINER != '' && vars.DEPLOY_CONTAINER || secrets.DEPLOY_CONTAINER }}
+          DEPLOY_CONTAINER_PATH: ${{ vars.DEPLOY_CONTAINER_PATH != '' && vars.DEPLOY_CONTAINER_PATH || secrets.DEPLOY_CONTAINER_PATH }}
           DEPLOY_HOST: ${{ vars.DEPLOY_HOST != '' && vars.DEPLOY_HOST || secrets.DEPLOY_HOST }}
           DEPLOY_PATH: ${{ vars.DEPLOY_PATH != '' && vars.DEPLOY_PATH || secrets.DEPLOY_PATH }}
           DEPLOY_PORT: ${{ vars.DEPLOY_PORT != '' && vars.DEPLOY_PORT || secrets.DEPLOY_PORT }}
           DEPLOY_USER: ${{ vars.DEPLOY_USER != '' && vars.DEPLOY_USER || secrets.DEPLOY_USER }}
+          REMOTE_STAGE_DIR: /tmp/lexyalgo-static-export-${{ github.run_id }}-${{ github.run_attempt }}
         shell: bash
         run: |
-          if [ -z "$DEPLOY_HOST" ] || [ -z "$DEPLOY_USER" ] || [ -z "$DEPLOY_PATH" ]; then
-            echo "Missing one of DEPLOY_HOST, DEPLOY_USER, or DEPLOY_PATH (env vars or secrets)" >&2
+          if [ -z "$DEPLOY_HOST" ] || [ -z "$DEPLOY_USER" ]; then
+            echo "Missing one of DEPLOY_HOST or DEPLOY_USER (env vars or secrets)" >&2
+            exit 1
+          fi
+
+          if [ -n "$DEPLOY_CONTAINER" ] && [ -z "$DEPLOY_CONTAINER_PATH" ]; then
+            echo "DEPLOY_CONTAINER_PATH is required when DEPLOY_CONTAINER is set" >&2
+            exit 1
+          fi
+
+          if [ -z "$DEPLOY_CONTAINER" ] && [ -z "$DEPLOY_PATH" ]; then
+            echo "Missing DEPLOY_PATH for host-path deploy, or set DEPLOY_CONTAINER + DEPLOY_CONTAINER_PATH for container deploy" >&2
             exit 1
           fi
 
           port="$DEPLOY_PORT"
           [ -n "$port" ] || port=22
+
+          ssh -i ~/.ssh/id_ed25519 -p "$port" "$DEPLOY_USER@$DEPLOY_HOST" "rm -rf '$REMOTE_STAGE_DIR' && mkdir -p '$REMOTE_STAGE_DIR'"
 
           rsync \
             --archive \
@@ -176,7 +191,37 @@ jobs:
             --delete \
             --human-readable \
             -e "ssh -i ~/.ssh/id_ed25519 -p $port" \
-            out/ "$DEPLOY_USER@$DEPLOY_HOST:$DEPLOY_PATH/"
+            out/ "$DEPLOY_USER@$DEPLOY_HOST:$REMOTE_STAGE_DIR/"
+
+      - name: Promote staged artifact to live target
+        env:
+          DEPLOY_CONTAINER: ${{ vars.DEPLOY_CONTAINER != '' && vars.DEPLOY_CONTAINER || secrets.DEPLOY_CONTAINER }}
+          DEPLOY_CONTAINER_PATH: ${{ vars.DEPLOY_CONTAINER_PATH != '' && vars.DEPLOY_CONTAINER_PATH || secrets.DEPLOY_CONTAINER_PATH }}
+          DEPLOY_HOST: ${{ vars.DEPLOY_HOST != '' && vars.DEPLOY_HOST || secrets.DEPLOY_HOST }}
+          DEPLOY_PATH: ${{ vars.DEPLOY_PATH != '' && vars.DEPLOY_PATH || secrets.DEPLOY_PATH }}
+          DEPLOY_PORT: ${{ vars.DEPLOY_PORT != '' && vars.DEPLOY_PORT || secrets.DEPLOY_PORT }}
+          DEPLOY_USER: ${{ vars.DEPLOY_USER != '' && vars.DEPLOY_USER || secrets.DEPLOY_USER }}
+          REMOTE_STAGE_DIR: /tmp/lexyalgo-static-export-${{ github.run_id }}-${{ github.run_attempt }}
+        shell: bash
+        run: |
+          port="$DEPLOY_PORT"
+          [ -n "$port" ] || port=22
+
+          if [ -n "$DEPLOY_CONTAINER" ]; then
+            ssh -i ~/.ssh/id_ed25519 -p "$port" "$DEPLOY_USER@$DEPLOY_HOST" \
+              "set -e; \
+              docker inspect '$DEPLOY_CONTAINER' >/dev/null; \
+              docker exec '$DEPLOY_CONTAINER' sh -lc 'mkdir -p '\''$DEPLOY_CONTAINER_PATH'\''' ; \
+              tar -C '$REMOTE_STAGE_DIR' -cf - . | docker exec -i '$DEPLOY_CONTAINER' sh -lc 'rm -rf '\''$DEPLOY_CONTAINER_PATH'\''/* '\''$DEPLOY_CONTAINER_PATH'\''/.[!.]* '\''$DEPLOY_CONTAINER_PATH'\''/..?* 2>/dev/null || true; mkdir -p '\''$DEPLOY_CONTAINER_PATH'\''; tar -xf - -C '\''$DEPLOY_CONTAINER_PATH'\''' ; \
+              rm -rf '$REMOTE_STAGE_DIR'"
+          else
+            ssh -i ~/.ssh/id_ed25519 -p "$port" "$DEPLOY_USER@$DEPLOY_HOST" \
+              "set -e; \
+              mkdir -p '$DEPLOY_PATH'; \
+              rm -rf '$DEPLOY_PATH'/* '$DEPLOY_PATH'/.[!.]* '$DEPLOY_PATH'/..?* 2>/dev/null || true; \
+              tar -C '$REMOTE_STAGE_DIR' -cf - . | tar -xf - -C '$DEPLOY_PATH'; \
+              rm -rf '$REMOTE_STAGE_DIR'"
+          fi
 
       - name: Verify deployed build metadata
         env:

--- a/docs/STAGING-AND-RELEASE.md
+++ b/docs/STAGING-AND-RELEASE.md
@@ -45,15 +45,17 @@ Environment variables:
 - `DEPLOY_HOST` - Hostinger SSH host
 - `DEPLOY_PORT` - optional, defaults to `22`
 - `DEPLOY_USER` - SSH user for the target account
-- `DEPLOY_PATH` - remote publish directory (the confirmed docroot for that environment)
 - `DEPLOY_BASE_URL` - site base URL used for post-deploy verification
 - `DEPLOY_KNOWN_HOSTS` - optional pinned host key block; if omitted the workflow falls back to `ssh-keyscan`
+- choose one target mode:
+  - host-path mode: `DEPLOY_PATH` - remote publish directory already served by the web server
+  - container mode: `DEPLOY_CONTAINER` plus `DEPLOY_CONTAINER_PATH`
 
 Environment secret:
-- `DEPLOY_SSH_KEY` - private key with write access to the publish directory
+- `DEPLOY_SSH_KEY` - private key with write access to the target host
 
 Compatibility note:
-- the workflow accepts `DEPLOY_HOST`, `DEPLOY_PORT`, `DEPLOY_USER`, `DEPLOY_PATH`, `DEPLOY_BASE_URL`, and `DEPLOY_KNOWN_HOSTS` from either environment variables or secrets
+- the workflow accepts `DEPLOY_HOST`, `DEPLOY_PORT`, `DEPLOY_USER`, `DEPLOY_PATH`, `DEPLOY_CONTAINER`, `DEPLOY_CONTAINER_PATH`, `DEPLOY_BASE_URL`, and `DEPLOY_KNOWN_HOSTS` from either environment variables or secrets
 - `DEPLOY_SSH_KEY` must remain a secret
 
 ### What the workflow proves
@@ -66,12 +68,13 @@ Compatibility note:
 
 ### First-time setup checklist
 
-1. confirm the exact Hostinger SSH host, user, and docroot for both staging and production
-2. add the environment variables and `DEPLOY_SSH_KEY` secret above in GitHub
-3. run the workflow manually against `staging`
-4. verify `https://staging.lexyalgo.com/build-meta.json` returns the expected SHA
-5. smoke-test the staging URLs listed below
-6. once staging is clean, let the `main` push path handle production deploys
+1. confirm the exact Hostinger SSH host and user for both staging and production
+2. decide whether each environment is a host-path deploy or a container deploy
+3. add the environment variables and `DEPLOY_SSH_KEY` secret above in GitHub
+4. run the workflow manually against `staging`
+5. verify `https://staging.lexyalgo.com/build-meta.json` returns the expected SHA
+6. smoke-test the staging URLs listed below
+7. once staging is clean, let the `main` push path handle production deploys
 
 ## Minimum smoke checklist
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,9 +2,11 @@
 
 ## Current hosting shape
 
-Known production proof from issue tracking:
+Known production proof from issue tracking and live Hostinger inspection:
 
-- `lexyalgo.com` is serving through nginx on a Hostinger-hosted server.
+- `lexyalgo.com` and `staging.lexyalgo.com` are fronted by Traefik on a Hostinger-hosted server.
+- Production currently routes to container `lexyalgo-site` on port `3000`.
+- Staging currently routes to container `lexyalgo-site-staging` on port `3000`.
 - The site is a static Next.js export.
 - This repository is the source of truth for the build and now also carries the deploy workflow for Hostinger.
 
@@ -34,8 +36,9 @@ On every push to `main`, `Deploy static export` will:
 1. resolve the deploy target to `production`
 2. build the static export
 3. upload the `static-export` artifact
-4. deploy to production via `rsync` over SSH
-5. verify `https://lexyalgo.com/build-meta.json` matches the built SHA, if `DEPLOY_BASE_URL` is configured for the environment
+4. stage the built artifact on Hostinger over SSH
+5. promote the staged artifact either into a live container or a plain host path, depending on environment wiring
+6. verify `https://lexyalgo.com/build-meta.json` matches the built SHA, if `DEPLOY_BASE_URL` is configured for the environment
 
 ### Manual deploy
 
@@ -60,7 +63,7 @@ Environment names:
 Environment variables:
 - `DEPLOY_HOST`
 - `DEPLOY_USER`
-- `DEPLOY_PATH`
+- either `DEPLOY_PATH` for a plain host-path deploy, or both `DEPLOY_CONTAINER` and `DEPLOY_CONTAINER_PATH` for a container-backed deploy
 
 Environment secret:
 - `DEPLOY_SSH_KEY`
@@ -74,15 +77,28 @@ Environment variables or secrets:
 
 See [`docs/github-environment-bootstrap.md`](./github-environment-bootstrap.md) for the exact bootstrap checklist.
 
-## Host path expectations
+## Target path expectations
 
-The workflow syncs the contents of `out/` directly into the configured web root:
+The workflow always stages the built `out/` directory onto the Hostinger box first.
 
-```bash
-rsync -az --delete ./out/ user@host:/var/www/lexyalgo.com/
-```
+From there it supports two deploy modes:
 
-Set `DEPLOY_PATH` to the directory nginx already serves for that hostname.
+### Container-backed deploy
+
+If `DEPLOY_CONTAINER` is set, the workflow streams the staged artifact into the running container and replaces the configured container path.
+
+Current known live Lexy targets:
+
+- production container: `lexyalgo-site`
+- production container path: `/usr/share/nginx/html`
+- staging container: `lexyalgo-site-staging`
+- staging container path: `/app/out`
+
+### Plain host-path deploy
+
+If `DEPLOY_CONTAINER` is not set, the workflow replaces the configured host path directly.
+
+Set `DEPLOY_PATH` to the directory the web server already serves for that hostname.
 
 ## Contact form activation
 

--- a/docs/github-environment-bootstrap.md
+++ b/docs/github-environment-bootstrap.md
@@ -16,7 +16,7 @@ Set these values on **each** environment.
 Environment variables:
 - `DEPLOY_HOST`
 - `DEPLOY_USER`
-- `DEPLOY_PATH`
+- either `DEPLOY_PATH`, or both `DEPLOY_CONTAINER` and `DEPLOY_CONTAINER_PATH`
 
 Environment secret:
 - `DEPLOY_SSH_KEY`
@@ -32,8 +32,10 @@ Environment variables or secrets:
 
 - `DEPLOY_HOST`: SSH host or IP for the Hostinger target
 - `DEPLOY_USER`: SSH username
-- `DEPLOY_PATH`: nginx web root for the static site on that host
-- `DEPLOY_SSH_KEY`: private key allowed to write to `DEPLOY_PATH`
+- `DEPLOY_PATH`: web root for a plain host-path deploy on that host
+- `DEPLOY_CONTAINER`: running container name for a container-backed deploy
+- `DEPLOY_CONTAINER_PATH`: directory inside the running container that should be replaced with the built static export
+- `DEPLOY_SSH_KEY`: private key allowed to SSH to the deploy host and write to the chosen target
 - `DEPLOY_PORT`: SSH port if not `22`
 - `DEPLOY_KNOWN_HOSTS`: exact `known_hosts` line for the target host
 - `DEPLOY_BASE_URL`: public base URL, for example `https://staging.lexyalgo.com` or `https://lexyalgo.com`
@@ -64,6 +66,24 @@ After wiring `production`:
 
 ## Quick operator note
 
-The workflow now accepts the non-sensitive deploy connection values from **environment variables or environment secrets**. `DEPLOY_SSH_KEY` must still be stored as an environment secret. If the environment exists but `DEPLOY_HOST` or `DEPLOY_SSH_KEY` is missing, the run will still fail early with:
+The workflow now accepts the non-sensitive deploy connection values from **environment variables or environment secrets**. `DEPLOY_SSH_KEY` must still be stored as an environment secret.
+
+For the currently observed Lexy Hostinger layout, the environment values should be:
+
+### staging
+- `DEPLOY_HOST=82.25.93.50`
+- `DEPLOY_USER=root`
+- `DEPLOY_CONTAINER=lexyalgo-site-staging`
+- `DEPLOY_CONTAINER_PATH=/app/out`
+- `DEPLOY_BASE_URL=https://staging.lexyalgo.com`
+
+### production
+- `DEPLOY_HOST=82.25.93.50`
+- `DEPLOY_USER=root`
+- `DEPLOY_CONTAINER=lexyalgo-site`
+- `DEPLOY_CONTAINER_PATH=/usr/share/nginx/html`
+- `DEPLOY_BASE_URL=https://lexyalgo.com`
+
+If the environment exists but `DEPLOY_HOST` or `DEPLOY_SSH_KEY` is missing, the run will still fail early with:
 
 `Missing DEPLOY_HOST (env var or secret) or DEPLOY_SSH_KEY (secret) for environment <name>`


### PR DESCRIPTION
## Summary
- teach `deploy-static-export.yml` a container-backed deploy mode for the real Hostinger layout
- keep plain host-path deploy support for environments that still publish to a normal docroot
- update deploy docs/bootstrap notes with the verified live Lexy container targets

## Why
Issue #30 was no longer just “missing env vars.” Live inspection on the Hostinger box showed:
- `lexyalgo.com` -> Traefik -> `lexyalgo-site:3000`
- `staging.lexyalgo.com` -> Traefik -> `lexyalgo-site-staging:3000`
- staging container has no host volume mounts
- production container serves baked static files from `/usr/share/nginx/html`

So the previous rsync-to-docroot workflow could not be considered a real deploy path for the current live setup.

## Workflow behavior after this PR
- build `out/` as before
- stage artifact over SSH onto the Hostinger box
- if `DEPLOY_CONTAINER` is set, stream the staged artifact into the running container and replace `DEPLOY_CONTAINER_PATH`
- otherwise, fall back to replacing `DEPLOY_PATH` on the host
- verify `build-meta.json` against the built SHA when `DEPLOY_BASE_URL` is configured

## Verified live Lexy targets documented here
- staging: `lexyalgo-site-staging` -> `/app/out`
- production: `lexyalgo-site` -> `/usr/share/nginx/html`

## Checks
- `git diff --check`
- YAML parse check for `.github/workflows/deploy-static-export.yml` (`yaml-ok`)

Closes #30
