### PR TITLE
fix: keep remote container path expansion on target host

### DIFF
--- a/.github/workflows/deploy-static-export.yml
+++ b/.github/workflows/deploy-static-export.yml
@@ -213,18 +213,18 @@ jobs:
           set -e
           docker inspect "$DEPLOY_CONTAINER" >/dev/null
           target="$DEPLOY_CONTAINER_PATH"
-          parent=$(dirname "$target")
-          base=$(basename "$target")
-          incoming="$parent/.$base.incoming-$RUN_SUFFIX"
-          backup="$parent/.$base.previous-$RUN_SUFFIX"
-          docker exec -e TARGET_PATH="$DEPLOY_CONTAINER_PATH" -e TARGET_PARENT="$parent" -e INCOMING_PATH="$incoming" -e BACKUP_PATH="$backup" "$DEPLOY_CONTAINER" sh -lc '
+          parent=\$(dirname "\$target")
+          base=\$(basename "\$target")
+          incoming="\$parent/.\$base.incoming-$RUN_SUFFIX"
+          backup="\$parent/.\$base.previous-$RUN_SUFFIX"
+          docker exec -e TARGET_PATH="\$target" -e TARGET_PARENT="\$parent" -e INCOMING_PATH="\$incoming" -e BACKUP_PATH="\$backup" "$DEPLOY_CONTAINER" sh -lc '
             set -e
             mkdir -p "$TARGET_PARENT"
             rm -rf "$INCOMING_PATH" "$BACKUP_PATH"
             mkdir -p "$INCOMING_PATH"
           '
-          tar -C "$REMOTE_STAGE_DIR" -cf - . | docker exec -i -e INCOMING_PATH="$incoming" "$DEPLOY_CONTAINER" sh -lc 'set -e; tar -xf - -C "$INCOMING_PATH"'
-          docker exec -e TARGET_PATH="$DEPLOY_CONTAINER_PATH" -e INCOMING_PATH="$incoming" -e BACKUP_PATH="$backup" "$DEPLOY_CONTAINER" sh -lc '
+          tar -C "$REMOTE_STAGE_DIR" -cf - . | docker exec -i -e INCOMING_PATH="\$incoming" "$DEPLOY_CONTAINER" sh -lc 'set -e; tar -xf - -C "$INCOMING_PATH"'
+          docker exec -e TARGET_PATH="\$target" -e INCOMING_PATH="\$incoming" -e BACKUP_PATH="\$backup" "$DEPLOY_CONTAINER" sh -lc '
             set -e
             if [ -e "$TARGET_PATH" ]; then mv "$TARGET_PATH" "$BACKUP_PATH"; fi
             mv "$INCOMING_PATH" "$TARGET_PATH"


### PR DESCRIPTION
Fixes #38

## What changed
- keep `dirname` and `basename` path resolution escaped inside the SSH heredoc
- pass the remote-computed `target`, `parent`, `incoming`, and `backup` values into `docker exec`
- preserve the artifact promotion flow from PR #37 without reintroducing runner-side path expansion

## Proof plan
- merge and let `Deploy static export` re-run on `main`
- verify the workflow passes `Promote staged artifact to live target`
- verify deployed `build-meta.json` matches the deployed commit SHA
