### PR TITLE
fix: run deploy promotion script entirely on remote host

### DIFF
--- a/.github/workflows/deploy-static-export.yml
+++ b/.github/workflows/deploy-static-export.yml
@@ -209,22 +209,23 @@ jobs:
           [ -n "$port" ] || port=22
 
           if [ -n "$DEPLOY_CONTAINER" ]; then
-            ssh -i ~/.ssh/id_ed25519 -p "$port" "$DEPLOY_USER@$DEPLOY_HOST" /bin/sh <<EOF
+            ssh -i ~/.ssh/id_ed25519 -p "$port" "$DEPLOY_USER@$DEPLOY_HOST" \
+              "DEPLOY_CONTAINER='$DEPLOY_CONTAINER' DEPLOY_CONTAINER_PATH='$DEPLOY_CONTAINER_PATH' REMOTE_STAGE_DIR='$REMOTE_STAGE_DIR' RUN_SUFFIX='$RUN_SUFFIX' /bin/sh" <<'EOF'
           set -e
           docker inspect "$DEPLOY_CONTAINER" >/dev/null
           target="$DEPLOY_CONTAINER_PATH"
-          parent=\$(dirname "\$target")
-          base=\$(basename "\$target")
-          incoming="\$parent/.\$base.incoming-$RUN_SUFFIX"
-          backup="\$parent/.\$base.previous-$RUN_SUFFIX"
-          docker exec -e TARGET_PATH="\$target" -e TARGET_PARENT="\$parent" -e INCOMING_PATH="\$incoming" -e BACKUP_PATH="\$backup" "$DEPLOY_CONTAINER" sh -lc '
+          parent=$(dirname "$target")
+          base=$(basename "$target")
+          incoming="$parent/.$base.incoming-$RUN_SUFFIX"
+          backup="$parent/.$base.previous-$RUN_SUFFIX"
+          docker exec -e TARGET_PATH="$target" -e TARGET_PARENT="$parent" -e INCOMING_PATH="$incoming" -e BACKUP_PATH="$backup" "$DEPLOY_CONTAINER" sh -lc '
             set -e
             mkdir -p "$TARGET_PARENT"
             rm -rf "$INCOMING_PATH" "$BACKUP_PATH"
             mkdir -p "$INCOMING_PATH"
           '
-          tar -C "$REMOTE_STAGE_DIR" -cf - . | docker exec -i -e INCOMING_PATH="\$incoming" "$DEPLOY_CONTAINER" sh -lc 'set -e; tar -xf - -C "$INCOMING_PATH"'
-          docker exec -e TARGET_PATH="\$target" -e INCOMING_PATH="\$incoming" -e BACKUP_PATH="\$backup" "$DEPLOY_CONTAINER" sh -lc '
+          tar -C "$REMOTE_STAGE_DIR" -cf - . | docker exec -i -e INCOMING_PATH="$incoming" "$DEPLOY_CONTAINER" sh -lc 'set -e; tar -xf - -C "$INCOMING_PATH"'
+          docker exec -e TARGET_PATH="$target" -e INCOMING_PATH="$incoming" -e BACKUP_PATH="$backup" "$DEPLOY_CONTAINER" sh -lc '
             set -e
             if [ -e "$TARGET_PATH" ]; then mv "$TARGET_PATH" "$BACKUP_PATH"; fi
             mv "$INCOMING_PATH" "$TARGET_PATH"
@@ -233,20 +234,21 @@ jobs:
           rm -rf "$REMOTE_STAGE_DIR"
           EOF
           else
-            ssh -i ~/.ssh/id_ed25519 -p "$port" "$DEPLOY_USER@$DEPLOY_HOST" /bin/sh <<EOF
+            ssh -i ~/.ssh/id_ed25519 -p "$port" "$DEPLOY_USER@$DEPLOY_HOST" \
+              "DEPLOY_PATH='$DEPLOY_PATH' REMOTE_STAGE_DIR='$REMOTE_STAGE_DIR' RUN_SUFFIX='$RUN_SUFFIX' /bin/sh" <<'EOF'
           set -e
-          target='$DEPLOY_PATH'
-          parent=\$(dirname "\$target")
-          base=\$(basename "\$target")
-          incoming="\$parent/.\$base.incoming-$RUN_SUFFIX"
-          backup="\$parent/.\$base.previous-$RUN_SUFFIX"
-          mkdir -p "\$parent"
-          rm -rf "\$incoming" "\$backup"
-          mkdir -p "\$incoming"
-          tar -C '$REMOTE_STAGE_DIR' -cf - . | tar -xf - -C "\$incoming"
-          if [ -e "\$target" ]; then mv "\$target" "\$backup"; fi
-          mv "\$incoming" "\$target"
-          rm -rf "\$backup" '$REMOTE_STAGE_DIR'
+          target="$DEPLOY_PATH"
+          parent=$(dirname "$target")
+          base=$(basename "$target")
+          incoming="$parent/.$base.incoming-$RUN_SUFFIX"
+          backup="$parent/.$base.previous-$RUN_SUFFIX"
+          mkdir -p "$parent"
+          rm -rf "$incoming" "$backup"
+          mkdir -p "$incoming"
+          tar -C "$REMOTE_STAGE_DIR" -cf - . | tar -xf - -C "$incoming"
+          if [ -e "$target" ]; then mv "$target" "$backup"; fi
+          mv "$incoming" "$target"
+          rm -rf "$backup" "$REMOTE_STAGE_DIR"
           EOF
           fi
 


### PR DESCRIPTION
Refs #38

## What changed
- run the SSH deploy scripts through quoted heredocs so the workflow runner no longer partially expands remote shell logic
- pass deploy values into the remote shell command explicitly before `/bin/sh`
- compute target, parent, incoming, and backup paths entirely on the target host for both container and non-container deploy modes

## Proof plan
- let PR build pass
- merge to `main`
- verify `Deploy static export` passes `Promote staged artifact to live target`
- verify `Verify deployed build metadata` succeeds on the live target
