### PR TITLE
Expose public alpha tools on the main site

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@ Marketing site for [lexyalgo.com](https://lexyalgo.com) — a house of brands fo
 
 ## Live Products
 - **Support Calculator** — Free child support and retirement division calculators
+- **QDRO Services** — Live intake and document generation flow
+- **Estate Planning** — Free beta access for wills, trusts, POAs, and healthcare directives
 
-## Coming Soon
+## Public Alpha Products
+- **Divorce Forms** — Court-form-driven divorce documents
 - **Asset Divider** — Visual property division with behavioral design
 - **Co-Parent** — Shared calendar, expense tracking, communication
-- **Document Generation** — Court-form-driven divorce documents
 - **LexyFiling** — E-filing integration
 
 ## Tech Stack

--- a/docs/STAGING-AND-RELEASE.md
+++ b/docs/STAGING-AND-RELEASE.md
@@ -84,8 +84,15 @@ After a staging or production push, verify:
 2. primary product sections render
 3. nav links work without routing failures
 4. blog/content pages render from the built static output
-5. waitlist or contact surfaces do not throw client errors
+5. contact and public-alpha entry surfaces do not throw client errors
 6. `build-meta.json` reports the expected commit SHA
+
+## Content/release notes
+
+Current live product framing in this repo:
+- Support Calculator and QDRO Services are live references
+- Estate Planning is a free beta reference
+- Divorce Forms, Asset Divider, Co-Parent, and LexyFiling are public-alpha references exposed on the main site
 
 ## Proof to keep with each release
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,12 +7,12 @@ const TRY_NOW_FREE_URL = 'https://doc.lexyalgo.com/interview?i=docassemble.Estat
 const divorceProducts = [
   {
     name: 'Divorce Forms',
-    description: 'Full uncontested divorce document generation. One guided intake → court-form-driven documents for your state. CT and CA launching first.',
+    description: 'Full uncontested divorce document generation is now public alpha. One guided intake leads to court-form-driven documents for your state, with CT and CA first.',
     href: '/products/divorce',
     color: '#2B4580',
     lightBg: '#E8EEF8',
     icon: '📄',
-    badge: 'Coming Soon',
+    badge: 'Public Alpha',
     live: false,
   },
   {
@@ -37,32 +37,32 @@ const divorceProducts = [
   },
   {
     name: 'Asset Divider',
-    description: 'Visual drag-and-drop property division with fairness scoring. Every trade-off framed as a gain, not a loss.',
+    description: 'Visual drag-and-drop property division with fairness scoring, now exposed on the site as a public alpha.',
     href: '/products/asset-divider',
     color: '#B02700',
     lightBg: '#FFEDE8',
     icon: '⚖️',
-    badge: 'Coming Soon',
+    badge: 'Public Alpha',
     live: false,
   },
   {
     name: 'Co-Parent',
-    description: 'Shared calendar, expense tracking, and communication tools designed around positive parenting time — not conflict.',
+    description: 'Shared calendar, expense tracking, and communication tools designed around positive parenting time, now visible as a public alpha.',
     href: '/products/co-parent',
     color: '#2E6B4F',
     lightBg: '#E6F5EC',
     icon: '📅',
-    badge: 'Coming Soon',
+    badge: 'Public Alpha',
     live: false,
   },
   {
     name: 'LexyFiling',
-    description: 'E-filing integration that submits your completed documents directly to the court. No printing, no mailing, no courthouse lines.',
+    description: 'E-filing integration that submits completed documents directly to the court, now exposed on the site as a public alpha.',
     href: '/products/filing',
     color: '#4B3D7A',
     lightBg: '#EDE9F8',
     icon: '📁',
-    badge: 'Coming Soon',
+    badge: 'Public Alpha',
     live: false,
   },
 ]
@@ -114,7 +114,7 @@ function ProductCard({
         <div className="flex h-12 w-12 items-center justify-center rounded-xl text-2xl" style={{ backgroundColor: product.lightBg }}>
           {product.icon}
         </div>
-        <span className={`rounded-full px-3 py-1 text-xs font-medium ${product.live ? 'bg-green-100 text-green-700' : product.badge === 'Free Beta' ? 'bg-amber-100 text-amber-700' : 'bg-violet-100 text-violet-700'}`}>
+        <span className={`rounded-full px-3 py-1 text-xs font-medium ${product.live ? 'bg-green-100 text-green-700' : product.badge === 'Free Beta' ? 'bg-amber-100 text-amber-700' : product.badge === 'Public Alpha' ? 'bg-sky-100 text-sky-700' : 'bg-violet-100 text-violet-700'}`}>
           {product.badge}
         </span>
       </div>
@@ -123,7 +123,7 @@ function ProductCard({
       </h3>
       <p className="mt-3 text-sm leading-relaxed text-slate-600">{product.description}</p>
       <div className="mt-5 flex items-center text-sm font-semibold transition-colors" style={{ color: product.color }}>
-        {product.live ? 'Get started' : 'Join waitlist'}
+        {product.live ? 'Get started' : product.badge === 'Public Alpha' ? 'Open public alpha' : product.badge === 'Free Beta' ? 'Open free beta' : 'Learn more'}
         <svg className="ml-1 h-4 w-4 transition-transform group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" /></svg>
       </div>
     </Link>
@@ -398,7 +398,7 @@ export default function HomePage() {
                   {estatePlanningProduct.description}
                 </p>
                 <div className="mt-6 border-l-4 border-[color:#7A5C1E] bg-[color:rgba(122,92,30,.08)] px-4 py-3 text-sm text-slate-700">
-                  Free beta access now, with the same Sanctuary-style clarity and guided workflow as the rest of LexyAlgo.
+                  Free beta access is live now, with the same plain-English clarity and guided workflow as the rest of LexyAlgo.
                 </div>
               </div>
             </div>

--- a/src/app/products/asset-divider/page.tsx
+++ b/src/app/products/asset-divider/page.tsx
@@ -1,12 +1,13 @@
 import Link from 'next/link'
 import type { Metadata } from 'next'
-import { WaitlistForm } from '@/components/WaitlistForm'
 import { RealScreenshot } from '@/components/RealScreenshot'
 
 export const metadata: Metadata = {
-  title: 'Asset Divider — Coming Soon — LexyAlgo',
-  description: 'Visual asset division with drag-and-drop allocation and fairness scoring. Coming soon.',
+  title: 'Asset Divider — Public Alpha — LexyAlgo',
+  description: 'Visual asset division with drag-and-drop allocation and fairness scoring, now visible as a public alpha.',
 }
+
+const PUBLIC_ALPHA_URL = 'https://app.lexyalgo.com'
 
 const features = [
   { title: 'Visual Asset Inventory', desc: 'See every asset and debt in one dashboard — house, cars, retirement, bank accounts, personal property.' },
@@ -27,23 +28,43 @@ export default function AssetDividerPage() {
             <div>
               <span className="inline-flex items-center gap-2 text-sm font-semibold text-ember uppercase tracking-wider">
                 <span className="w-2.5 h-2.5 rounded-full bg-ember" />
-                Asset Divider — Coming Soon
+                Asset Divider — Public Alpha
               </span>
               <h1 className="font-[family-name:var(--font-space)] text-4xl sm:text-5xl font-bold text-slate-900 mt-4 leading-tight">
                 Divide property without the heartache
               </h1>
               <p className="mt-6 text-lg text-slate-600 leading-relaxed">
-                A visual workspace that turns the most stressful part of divorce — splitting everything you built together — into clear, fair decisions. Every trade-off framed as a gain.
+                A visual workspace, now visible in public alpha, that turns the most stressful part of divorce, splitting everything you built together, into clear, fair decisions. Every trade-off framed as a gain.
               </p>
-              <div className="mt-6">
-                <Link href="/calculator"
-                  className="inline-flex items-center text-sm font-semibold text-teal hover:underline"
+              <div className="mt-8 flex flex-col sm:flex-row gap-4">
+                <a href={PUBLIC_ALPHA_URL}
+                  className="inline-flex items-center justify-center bg-ember text-white font-semibold px-8 py-4 rounded-2xl hover:bg-[#861B00] transition-all shadow-lg shadow-ember/20 active:scale-[0.98]"
                 >
-                  Try our free calculators while you wait →
+                  Open Public Alpha
+                </a>
+                <Link href="/calculator"
+                  className="inline-flex items-center justify-center border-2 border-slate-200 text-slate-700 font-semibold px-8 py-4 rounded-2xl hover:border-slate-300 hover:bg-slate-50 transition-all"
+                >
+                  Open calculators
                 </Link>
               </div>
             </div>
-            <WaitlistForm product="Asset Divider" accentColor="#B02700" accentHover="#861B00" />
+            <div className="rounded-3xl border border-ember/10 bg-white p-8 shadow-xl shadow-ember/10">
+              <div className="inline-flex items-center gap-2 rounded-full bg-ember-light px-3 py-1 text-xs font-semibold uppercase tracking-wider text-ember">
+                Public Alpha Access
+              </div>
+              <h2 className="mt-5 font-[family-name:var(--font-space)] text-2xl font-bold text-slate-900">
+                This workspace is exposed for public testing
+              </h2>
+              <p className="mt-3 text-sm leading-relaxed text-slate-600">
+                Asset Divider is no longer buried behind a waitlist on the marketing site. People can reach the alpha directly from here.
+              </p>
+              <a href={PUBLIC_ALPHA_URL}
+                className="mt-8 inline-flex w-full items-center justify-center rounded-2xl bg-ember px-6 py-4 text-center font-semibold text-white transition-all hover:bg-[#861B00] active:scale-[0.98]"
+              >
+                Launch Asset Divider Alpha
+              </a>
+            </div>
           </div>
         </div>
       </section>
@@ -80,10 +101,19 @@ export default function AssetDividerPage() {
       {/* Bottom CTA */}
       <section className="bg-peach py-16 sm:py-20 text-center">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <h2 className="font-[family-name:var(--font-space)] text-3xl font-bold text-slate-900">Don&rsquo;t miss the launch</h2>
-          <p className="mt-4 text-slate-700 max-w-lg mx-auto">Join the waitlist and be first to divide property with confidence.</p>
-          <div className="mt-8 max-w-xl mx-auto">
-            <WaitlistForm product="Asset Divider" accentColor="#B02700" accentHover="#861B00" compact />
+          <h2 className="font-[family-name:var(--font-space)] text-3xl font-bold text-slate-900">Test Asset Divider now</h2>
+          <p className="mt-4 text-slate-700 max-w-lg mx-auto">Public alpha is open on the site. Get into the workflow and pressure-test the property split experience.</p>
+          <div className="mt-8 flex flex-col sm:flex-row gap-4 justify-center">
+            <a href={PUBLIC_ALPHA_URL}
+              className="inline-flex items-center justify-center bg-ember text-white font-semibold px-8 py-4 rounded-2xl hover:bg-[#861B00] transition-all shadow-lg shadow-ember/20 active:scale-[0.98]"
+            >
+              Open Public Alpha
+            </a>
+            <Link href="/contact"
+              className="inline-flex items-center justify-center border-2 border-slate-300 text-slate-700 font-semibold px-8 py-4 rounded-2xl hover:border-slate-400 hover:bg-white transition-all"
+            >
+              Send feedback
+            </Link>
           </div>
         </div>
       </section>

--- a/src/app/products/co-parent/page.tsx
+++ b/src/app/products/co-parent/page.tsx
@@ -1,12 +1,13 @@
 import Link from 'next/link'
 import type { Metadata } from 'next'
-import { WaitlistForm } from '@/components/WaitlistForm'
 import { RealScreenshot } from '@/components/RealScreenshot'
 
 export const metadata: Metadata = {
-  title: 'Co-Parent — Coming Soon — LexyAlgo',
-  description: 'Shared calendar, expense tracking, and communication tools designed around positive parenting time. Coming soon.',
+  title: 'Co-Parent — Public Alpha — LexyAlgo',
+  description: 'Shared calendar, expense tracking, and communication tools designed around positive parenting time, now visible as a public alpha.',
 }
+
+const PUBLIC_ALPHA_URL = 'https://kid.lexyalgo.com/login'
 
 const features = [
   { title: 'Shared Calendar', desc: 'Visual parenting time calendar showing both parents\' schedules in positive, distinct colors. See your time — not what you\'re "missing."' },
@@ -27,23 +28,43 @@ export default function CoParentPage() {
             <div>
               <span className="inline-flex items-center gap-2 text-sm font-semibold text-sage uppercase tracking-wider">
                 <span className="w-2.5 h-2.5 rounded-full bg-sage" />
-                Co-Parent — Coming Soon
+                Co-Parent — Public Alpha
               </span>
               <h1 className="font-[family-name:var(--font-space)] text-4xl sm:text-5xl font-bold text-slate-900 mt-4 leading-tight">
                 Parenting together, separately
               </h1>
               <p className="mt-6 text-lg text-slate-600 leading-relaxed">
-                A co-parenting platform built around positive parenting time — not conflict. Shared calendars, expense tracking, and communication tools that keep the focus on your children.
+                A co-parenting platform built around positive parenting time, not conflict. It is now visible as a public alpha, with shared calendars, expense tracking, and communication tools that keep the focus on your children.
               </p>
-              <div className="mt-6">
-                <Link href="/calculator"
-                  className="inline-flex items-center text-sm font-semibold text-teal hover:underline"
+              <div className="mt-8 flex flex-col sm:flex-row gap-4">
+                <a href={PUBLIC_ALPHA_URL}
+                  className="inline-flex items-center justify-center bg-sage text-white font-semibold px-8 py-4 rounded-2xl hover:bg-[#1F4D38] transition-all shadow-lg shadow-sage/20 active:scale-[0.98]"
                 >
-                  Try our free calculators while you wait →
+                  Open Public Alpha
+                </a>
+                <Link href="/calculator"
+                  className="inline-flex items-center justify-center border-2 border-slate-200 text-slate-700 font-semibold px-8 py-4 rounded-2xl hover:border-slate-300 hover:bg-slate-50 transition-all"
+                >
+                  Open calculators
                 </Link>
               </div>
             </div>
-            <WaitlistForm product="Co-Parent" accentColor="#2E6B4F" accentHover="#1F4D38" />
+            <div className="rounded-3xl border border-sage/10 bg-white p-8 shadow-xl shadow-sage/10">
+              <div className="inline-flex items-center gap-2 rounded-full bg-sage-light px-3 py-1 text-xs font-semibold uppercase tracking-wider text-sage">
+                Public Alpha Access
+              </div>
+              <h2 className="mt-5 font-[family-name:var(--font-space)] text-2xl font-bold text-slate-900">
+                Co-Parent is exposed from the site
+              </h2>
+              <p className="mt-3 text-sm leading-relaxed text-slate-600">
+                Visitors can now reach the current co-parenting alpha directly from the product page instead of hitting a waitlist wall first.
+              </p>
+              <a href={PUBLIC_ALPHA_URL}
+                className="mt-8 inline-flex w-full items-center justify-center rounded-2xl bg-sage px-6 py-4 text-center font-semibold text-white transition-all hover:bg-[#1F4D38] active:scale-[0.98]"
+              >
+                Launch Co-Parent Alpha
+              </a>
+            </div>
           </div>
         </div>
       </section>
@@ -93,10 +114,19 @@ export default function CoParentPage() {
       {/* CTA */}
       <section className="bg-peach py-16 sm:py-20 text-center">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <h2 className="font-[family-name:var(--font-space)] text-3xl font-bold text-slate-900">Don&rsquo;t miss the launch</h2>
-          <p className="mt-4 text-slate-700 max-w-lg mx-auto">Join the waitlist and be first to co-parent with better tools.</p>
-          <div className="mt-8 max-w-xl mx-auto">
-            <WaitlistForm product="Co-Parent" accentColor="#2E6B4F" accentHover="#1F4D38" compact />
+          <h2 className="font-[family-name:var(--font-space)] text-3xl font-bold text-slate-900">Test Co-Parent now</h2>
+          <p className="mt-4 text-slate-700 max-w-lg mx-auto">The current alpha is reachable from the site. Open it, log in, and pressure-test the parenting workflow.</p>
+          <div className="mt-8 flex flex-col sm:flex-row gap-4 justify-center">
+            <a href={PUBLIC_ALPHA_URL}
+              className="inline-flex items-center justify-center bg-sage text-white font-semibold px-8 py-4 rounded-2xl hover:bg-[#1F4D38] transition-all shadow-lg shadow-sage/20 active:scale-[0.98]"
+            >
+              Open Public Alpha
+            </a>
+            <Link href="/contact"
+              className="inline-flex items-center justify-center border-2 border-slate-300 text-slate-700 font-semibold px-8 py-4 rounded-2xl hover:border-slate-400 hover:bg-white transition-all"
+            >
+              Send feedback
+            </Link>
           </div>
         </div>
       </section>

--- a/src/app/products/divorce/page.tsx
+++ b/src/app/products/divorce/page.tsx
@@ -1,12 +1,13 @@
 import Link from 'next/link'
 import type { Metadata } from 'next'
-import { WaitlistForm } from '@/components/WaitlistForm'
 import { RealScreenshot } from '@/components/RealScreenshot'
 
 export const metadata: Metadata = {
-  title: 'Divorce Forms — Coming Soon — LexyAlgo',
-  description: 'Full uncontested divorce document generation. One guided intake → court-form-driven documents for your state. CT and CA launching first.',
+  title: 'Divorce Forms — Public Alpha — LexyAlgo',
+  description: 'Full uncontested divorce document generation in public alpha. One guided intake → court-form-driven documents for your state. CT and CA launch first.',
 }
+
+const PUBLIC_ALPHA_URL = 'https://app.lexyalgo.com'
 
 const features = [
   { title: 'Court-Form-Mapped Documents', desc: 'Not generic templates — every document maps directly to your state\'s official court forms. The same forms the clerk expects to see.' },
@@ -27,23 +28,55 @@ export default function DivorcePage() {
             <div>
               <span className="inline-flex items-center gap-2 text-sm font-semibold text-[#2B4580] uppercase tracking-wider">
                 <span className="w-2.5 h-2.5 rounded-full bg-[#2B4580]" />
-                Divorce Forms — Coming Soon
+                Divorce Forms — Public Alpha
               </span>
               <h1 className="font-[family-name:var(--font-space)] text-4xl sm:text-5xl font-bold text-slate-900 mt-4 leading-tight">
                 One intake. Every form your court requires.
               </h1>
               <p className="mt-6 text-lg text-slate-600 leading-relaxed">
-                Full uncontested divorce document generation — court-form-driven, not generic templates. One guided intake produces every document your state requires. Connecticut and California launching first, more states coming.
+                Full uncontested divorce document generation is now public alpha, court-form-driven, not generic templates. One guided intake produces the document set your workflow needs. Connecticut and California lead the rollout, with more states behind them.
               </p>
-              <div className="mt-6">
-                <Link href="/calculator"
-                  className="inline-flex items-center text-sm font-semibold text-teal hover:underline"
+              <div className="mt-8 flex flex-col sm:flex-row gap-4">
+                <a href={PUBLIC_ALPHA_URL}
+                  className="inline-flex items-center justify-center bg-[#2B4580] text-white font-semibold px-8 py-4 rounded-2xl hover:bg-[#1C305A] transition-all shadow-lg shadow-[#2B4580]/20 hover:shadow-xl hover:shadow-[#2B4580]/30 active:scale-[0.98]"
                 >
-                  Try our free calculators while you wait →
+                  Open Public Alpha
+                  <svg className="ml-2 w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 8l4 4m0 0l-4 4m4-4H3" /></svg>
+                </a>
+                <Link href="/calculator"
+                  className="inline-flex items-center justify-center border-2 border-slate-200 text-slate-700 font-semibold px-8 py-4 rounded-2xl hover:border-slate-300 hover:bg-slate-50 transition-all"
+                >
+                  Open calculators
                 </Link>
               </div>
+              <p className="mt-4 text-xs text-slate-500">
+                Public alpha, open for real-world testing while we tighten the workflows in public.
+              </p>
             </div>
-            <WaitlistForm product="Divorce Forms" accentColor="#2B4580" accentHover="#1C305A" />
+            <div className="rounded-3xl border border-[#2B4580]/10 bg-white p-8 shadow-xl shadow-[#2B4580]/10">
+              <div className="inline-flex items-center gap-2 rounded-full bg-sky-50 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-[#2B4580]">
+                Public Alpha Access
+              </div>
+              <h2 className="mt-5 font-[family-name:var(--font-space)] text-2xl font-bold text-slate-900">
+                The tool is out on the site now
+              </h2>
+              <p className="mt-3 text-sm leading-relaxed text-slate-600">
+                We are exposing Divorce Forms directly so the public can test the product while we keep expanding the state coverage and workflow depth.
+              </p>
+              <ul className="mt-6 space-y-3 text-sm text-slate-700">
+                {['Public alpha is live', 'Court-form-driven workflow', 'CT and CA lead the rollout'].map((item) => (
+                  <li key={item} className="flex items-start gap-3">
+                    <span className="mt-0.5 flex h-5 w-5 items-center justify-center rounded-full bg-[#E8EEF8] text-[#2B4580]">✓</span>
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+              <a href={PUBLIC_ALPHA_URL}
+                className="mt-8 inline-flex w-full items-center justify-center rounded-2xl bg-[#2B4580] px-6 py-4 text-center font-semibold text-white transition-all hover:bg-[#1C305A] active:scale-[0.98]"
+              >
+                Launch Divorce Forms Alpha
+              </a>
+            </div>
           </div>
         </div>
       </section>
@@ -91,10 +124,19 @@ export default function DivorcePage() {
       {/* Bottom CTA */}
       <section className="bg-[#E8EEF8] py-16 sm:py-20 text-center">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <h2 className="font-[family-name:var(--font-space)] text-3xl font-bold text-slate-900">Be first when we launch</h2>
-          <p className="mt-4 text-slate-700 max-w-lg mx-auto">Join the waitlist for Divorce Forms — CT and CA first, more states following.</p>
-          <div className="mt-8 max-w-xl mx-auto">
-            <WaitlistForm product="Divorce Forms" accentColor="#2B4580" accentHover="#1C305A" compact />
+          <h2 className="font-[family-name:var(--font-space)] text-3xl font-bold text-slate-900">Test Divorce Forms now</h2>
+          <p className="mt-4 text-slate-700 max-w-lg mx-auto">Public alpha is open. Run the workflow, pressure-test it, and tell us where it breaks.</p>
+          <div className="mt-8 flex flex-col sm:flex-row gap-4 justify-center">
+            <a href={PUBLIC_ALPHA_URL}
+              className="inline-flex items-center justify-center bg-[#2B4580] text-white font-semibold px-8 py-4 rounded-2xl hover:bg-[#1C305A] transition-all shadow-lg shadow-[#2B4580]/20 active:scale-[0.98]"
+            >
+              Open Public Alpha
+            </a>
+            <Link href="/contact"
+              className="inline-flex items-center justify-center border-2 border-slate-300 text-slate-700 font-semibold px-8 py-4 rounded-2xl hover:border-slate-400 hover:bg-white transition-all"
+            >
+              Send feedback
+            </Link>
           </div>
         </div>
       </section>

--- a/src/app/products/filing/page.tsx
+++ b/src/app/products/filing/page.tsx
@@ -1,12 +1,13 @@
 import Link from 'next/link'
 import type { Metadata } from 'next'
-import { WaitlistForm } from '@/components/WaitlistForm'
 import { RealScreenshot } from '@/components/RealScreenshot'
 
 export const metadata: Metadata = {
-  title: 'LexyFiling — Coming Soon — LexyAlgo',
-  description: 'E-filing integration that submits your completed divorce documents directly to the court.',
+  title: 'LexyFiling — Public Alpha — LexyAlgo',
+  description: 'E-filing integration that submits completed divorce documents directly to the court, now visible as a public alpha.',
 }
+
+const PUBLIC_ALPHA_URL = 'https://filing.lexyalgo.com'
 
 export default function FilingPage() {
   return (
@@ -18,23 +19,43 @@ export default function FilingPage() {
             <div className="text-center lg:text-left">
               <span className="inline-flex items-center gap-2 text-sm font-semibold text-violet uppercase tracking-wider">
                 <span className="w-2.5 h-2.5 rounded-full bg-violet" />
-                LexyFiling — Coming Soon
+                LexyFiling — Public Alpha
               </span>
               <h1 className="font-[family-name:var(--font-space)] text-4xl sm:text-5xl font-bold text-slate-900 mt-4 leading-tight">
                 File without the courthouse
               </h1>
               <p className="mt-6 text-lg text-slate-600 leading-relaxed">
-                E-filing integration that takes your completed LexyAlgo documents and submits them directly to the court. No printing, no mailing, no waiting in line.
+                E-filing integration, now visible as a public alpha, that takes your completed LexyAlgo documents and submits them directly to the court. No printing, no mailing, no waiting in line.
               </p>
-              <div className="mt-6">
-                <Link href="/calculator"
-                  className="inline-flex items-center text-sm font-semibold text-teal hover:underline"
+              <div className="mt-8 flex flex-col sm:flex-row gap-4">
+                <a href={PUBLIC_ALPHA_URL}
+                  className="inline-flex items-center justify-center bg-violet text-white font-semibold px-8 py-4 rounded-2xl hover:bg-[#342A57] transition-all shadow-lg shadow-violet/20 active:scale-[0.98]"
                 >
-                  Try our free calculators while you wait →
+                  Open Public Alpha
+                </a>
+                <Link href="/calculator"
+                  className="inline-flex items-center justify-center border-2 border-slate-200 text-slate-700 font-semibold px-8 py-4 rounded-2xl hover:border-slate-300 hover:bg-slate-50 transition-all"
+                >
+                  Open calculators
                 </Link>
               </div>
             </div>
-            <WaitlistForm product="LexyFiling" accentColor="#4B3D7A" accentHover="#342A57" />
+            <div className="rounded-3xl border border-violet/10 bg-white p-8 shadow-xl shadow-violet/10">
+              <div className="inline-flex items-center gap-2 rounded-full bg-violet-light px-3 py-1 text-xs font-semibold uppercase tracking-wider text-violet">
+                Public Alpha Access
+              </div>
+              <h2 className="mt-5 font-[family-name:var(--font-space)] text-2xl font-bold text-slate-900">
+                LexyFiling is reachable now
+              </h2>
+              <p className="mt-3 text-sm leading-relaxed text-slate-600">
+                The e-filing product is no longer presented as a waitlist-only concept on the marketing site. Visitors can open the alpha directly.
+              </p>
+              <a href={PUBLIC_ALPHA_URL}
+                className="mt-8 inline-flex w-full items-center justify-center rounded-2xl bg-violet px-6 py-4 text-center font-semibold text-white transition-all hover:bg-[#342A57] active:scale-[0.98]"
+              >
+                Launch LexyFiling Alpha
+              </a>
+            </div>
           </div>
 
           <div className="mt-20 grid grid-cols-1 sm:grid-cols-3 gap-8 max-w-2xl mx-auto lg:max-w-none">


### PR DESCRIPTION
## Summary
- remove the remaining Sanctuary wording from the public site
- expose Divorce Forms, Asset Divider, Co-Parent, and LexyFiling as public alpha instead of coming-soon/waitlist-only surfaces
- update the product pages so visitors can open the alpha/beta tools directly

## Proof
- `npm run build`
- verified source no longer contains `Sanctuary` in `src/`
