### PR TITLE
fix: polish public marketing shell

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,6 +1,6 @@
 const contactInfo = [
   { label: 'Address', value: '1174 Whitney Avenue\nHamden, CT 06517-3432', icon: '📍' },
-  { label: 'Response times', value: 'We usually reply by email within 1 to 2 business days.', icon: '⏱️' },
+  { label: 'Response times', value: 'We usually reply within 1 to 2 business days.', icon: '⏱️' },
 ]
 
 const formAction = 'https://formsubmit.co/hello@lexyalgo.com'
@@ -9,7 +9,6 @@ const thankYouUrl = 'https://lexyalgo.com/contact/thanks'
 export default function ContactPage() {
   return (
     <>
-      {/* Hero */}
       <section className="bg-gradient-to-b from-surface to-white py-20 sm:py-28">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <h1 className="font-[family-name:var(--font-space)] text-4xl sm:text-5xl font-bold text-slate-900">Get in touch</h1>
@@ -19,10 +18,8 @@ export default function ContactPage() {
         </div>
       </section>
 
-      {/* Content */}
       <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pb-20">
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-12">
-          {/* Contact info */}
           <div className="space-y-8">
             {contactInfo.map((item) => (
               <div key={item.label} className="flex gap-4">
@@ -34,17 +31,13 @@ export default function ContactPage() {
               </div>
             ))}
 
-            <div className="mt-8 space-y-3 rounded-2xl bg-slate-100 p-6">
+            <div className="mt-8 rounded-2xl bg-slate-100 p-6">
               <p className="text-xs italic text-slate-500">
-                LexyAlgo provides document preparation tools and educational information, not legal advice.
-              </p>
-              <p className="text-xs text-slate-500">
-                For account or product questions, the contact form is the fastest way to reach us.
+                LexyAlgo provides document preparation tools, not legal advice. If you need an attorney, we&rsquo;re happy to point you in the right direction.
               </p>
             </div>
           </div>
 
-          {/* Contact form */}
           <div className="lg:col-span-2">
             <form
               action={formAction}
@@ -52,9 +45,9 @@ export default function ContactPage() {
               className="bg-white rounded-2xl border border-slate-200 p-8 sm:p-10 space-y-6"
             >
               <div className="rounded-2xl border border-teal/20 bg-teal/5 p-5">
-                <p className="text-sm font-semibold text-slate-900">Tell us what you need</p>
+                <p className="text-sm font-semibold text-slate-900">Send us a message</p>
                 <p className="mt-2 text-sm text-slate-700">
-                  Share a little context and we&rsquo;ll follow up with the best next step.
+                  Use the form below for product questions, feedback, partnerships, or press inquiries.
                 </p>
               </div>
 
@@ -87,6 +80,7 @@ export default function ContactPage() {
                   />
                 </div>
               </div>
+
               <div>
                 <label htmlFor="subject" className="block text-sm font-medium text-slate-700 mb-2">Subject</label>
                 <select
@@ -103,6 +97,7 @@ export default function ContactPage() {
                   <option>Other</option>
                 </select>
               </div>
+
               <div>
                 <label htmlFor="message" className="block text-sm font-medium text-slate-700 mb-2">Message</label>
                 <textarea
@@ -114,6 +109,7 @@ export default function ContactPage() {
                   required
                 />
               </div>
+
               <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                 <button
                   type="submit"
@@ -121,10 +117,7 @@ export default function ContactPage() {
                 >
                   Send message
                 </button>
-
-                <p className="text-sm text-slate-500">
-                  We review every message and reply by email.
-                </p>
+                <p className="text-sm text-slate-500">We usually reply within 1 to 2 business days.</p>
               </div>
             </form>
           </div>

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,6 +1,6 @@
 const contactInfo = [
   { label: 'Address', value: '1174 Whitney Avenue\nHamden, CT 06517-3432', icon: '📍' },
-  { label: 'Email', value: 'hello@lexyalgo.com', icon: '✉️' },
+  { label: 'Response times', value: 'We usually reply by email within 1 to 2 business days.', icon: '⏱️' },
 ]
 
 const formAction = 'https://formsubmit.co/hello@lexyalgo.com'
@@ -13,8 +13,8 @@ export default function ContactPage() {
       <section className="bg-gradient-to-b from-surface to-white py-20 sm:py-28">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <h1 className="font-[family-name:var(--font-space)] text-4xl sm:text-5xl font-bold text-slate-900">Get in touch</h1>
-          <p className="mt-4 text-lg text-slate-600 max-w-2xl">
-            Questions about our tools, partnership opportunities, or just want to say hello? We&rsquo;d love to hear from you.
+          <p className="mt-4 max-w-2xl text-lg text-slate-600">
+            Questions about our tools, product feedback, partnerships, or press? Send us a note and we&rsquo;ll route it to the right person.
           </p>
         </div>
       </section>
@@ -34,12 +34,12 @@ export default function ContactPage() {
               </div>
             ))}
 
-            <div className="bg-slate-100 rounded-2xl p-6 mt-8 space-y-3">
-              <p className="text-xs text-slate-500 italic">
-                LexyAlgo provides document preparation tools, not legal advice. If you need an attorney, we&rsquo;re happy to point you in the right direction.
+            <div className="mt-8 space-y-3 rounded-2xl bg-slate-100 p-6">
+              <p className="text-xs italic text-slate-500">
+                LexyAlgo provides document preparation tools and educational information, not legal advice.
               </p>
               <p className="text-xs text-slate-500">
-                Phone support stays hidden until a verified LexyAlgo support number is confirmed.
+                For account or product questions, the contact form is the fastest way to reach us.
               </p>
             </div>
           </div>
@@ -52,9 +52,9 @@ export default function ContactPage() {
               className="bg-white rounded-2xl border border-slate-200 p-8 sm:p-10 space-y-6"
             >
               <div className="rounded-2xl border border-teal/20 bg-teal/5 p-5">
-                <p className="text-sm font-semibold text-slate-900">Verified inbox delivery is now wired for the static site</p>
+                <p className="text-sm font-semibold text-slate-900">Tell us what you need</p>
                 <p className="mt-2 text-sm text-slate-700">
-                  Messages submit through FormSubmit with email verification, built-in CAPTCHA, and a hidden honeypot field for spam filtering.
+                  Share a little context and we&rsquo;ll follow up with the best next step.
                 </p>
               </div>
 
@@ -117,22 +117,15 @@ export default function ContactPage() {
               <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                 <button
                   type="submit"
-                  className="inline-flex items-center justify-center bg-teal text-white font-semibold px-8 py-3 rounded-xl hover:bg-[#12434D] transition-all shadow-sm shadow-teal/20 active:scale-[0.98]"
+                  className="inline-flex items-center justify-center rounded-xl bg-teal px-8 py-3 font-semibold text-white shadow-sm shadow-teal/20 transition-all hover:bg-[#12434D] active:scale-[0.98]"
                 >
-                  Send Message
+                  Send message
                 </button>
 
-                <a
-                  href="mailto:hello@lexyalgo.com?subject=LexyAlgo%20inquiry"
-                  className="text-sm font-medium text-teal hover:text-[#12434D]"
-                >
-                  Prefer email? hello@lexyalgo.com
-                </a>
+                <p className="text-sm text-slate-500">
+                  We review every message and reply by email.
+                </p>
               </div>
-
-              <p className="text-xs text-slate-500">
-                If this is the first live submission after deploy, FormSubmit will send an activation email to hello@lexyalgo.com before future messages start delivering.
-              </p>
             </form>
           </div>
         </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,7 +21,7 @@ const inter = Inter({
 
 export const metadata: Metadata = {
   title: 'LexyAlgo — Divorce Tools That Actually Help',
-  description: 'Divorce is hard. Your tools shouldn\'t be. Court-form-driven document preparation, asset division, co-parenting tools, and support calculators — built by an attorney licensed in 8 states.',
+  description: 'Divorce is hard. Your tools shouldn\'t be. Court-form-driven document preparation, calculators, and family-law workflows that help people move forward with more clarity.',
   openGraph: {
     title: 'LexyAlgo — Divorce Tools That Actually Help',
     description: 'Court-form-driven document preparation, asset division, co-parenting, and support calculators.',

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,10 @@
 import Link from 'next/link'
 import Image from 'next/image'
-import { WaitlistForm } from '@/components/WaitlistForm'
 
 const divorceProducts = [
   {
     name: 'Divorce Forms',
-    description: 'Full uncontested divorce document generation is now public alpha. One guided intake leads to court-form-driven documents for your state, with CT and CA first.',
+    description: 'Guided divorce-document workflows that turn one intake into the court forms your state requires, starting with Connecticut and California.',
     href: '/products/divorce',
     color: '#2B4580',
     lightBg: '#E8EEF8',
@@ -15,7 +14,7 @@ const divorceProducts = [
   },
   {
     name: 'QDRO Services',
-    description: 'Qualified Domestic Relations Order preparation — 33 plan-specific templates, attorney-prepared, flat-fee pricing. Already serving clients.',
+    description: 'Flat-fee QDRO generation for retirement-plan division, with plan-specific language and a live self-serve workflow.',
     href: '/products/qdro',
     color: '#8B5E3C',
     lightBg: '#F5EDE5',
@@ -25,7 +24,7 @@ const divorceProducts = [
   },
   {
     name: 'Calculators',
-    description: 'Free child support calculator, live now, with plain-English explanations and more calculators queued behind it.',
+    description: 'Free child support and retirement calculators with plain-English explanations and downloadable summaries.',
     href: '/calculator',
     color: '#1E5F6C',
     lightBg: '#E4F3F6',
@@ -35,7 +34,7 @@ const divorceProducts = [
   },
   {
     name: 'Asset Divider',
-    description: 'Visual drag-and-drop property division with fairness scoring, now exposed on the site as a public alpha.',
+    description: 'A visual property-division workspace for weighing tradeoffs, testing scenarios, and seeing balance in real time.',
     href: '/products/asset-divider',
     color: '#B02700',
     lightBg: '#FFEDE8',
@@ -45,7 +44,7 @@ const divorceProducts = [
   },
   {
     name: 'Co-Parent',
-    description: 'Shared calendar, expense tracking, and communication tools designed around positive parenting time, now visible as a public alpha.',
+    description: 'Shared calendars, expense tracking, and communication tools built to reduce friction after separation.',
     href: '/products/co-parent',
     color: '#2E6B4F',
     lightBg: '#E6F5EC',
@@ -55,7 +54,7 @@ const divorceProducts = [
   },
   {
     name: 'LexyFiling',
-    description: 'E-filing integration is planned, but not started yet. It stays on the roadmap as a coming-soon product.',
+    description: 'The future filing layer for completed workflows. It stays marked coming soon until the build is real.',
     href: '/products/filing',
     color: '#4B3D7A',
     lightBg: '#EDE9F8',
@@ -67,7 +66,7 @@ const divorceProducts = [
 
 const estatePlanningProduct = {
   name: 'Estate Planning',
-  description: 'Generate your Living Trust, Will, Power of Attorney, and Healthcare Directive with the same plain-English guidance — free during beta.',
+  description: 'Generate your living trust, will, power of attorney, and healthcare directive with the same plain-English guidance, free during beta.',
   href: '/products/estate-planning',
   color: '#7A5C1E',
   lightBg: '#FAF2DC',
@@ -76,17 +75,17 @@ const estatePlanningProduct = {
 }
 
 const trustBadges = [
-  { label: '8-State Attorney', detail: 'Built by a licensed attorney' },
-  { label: 'Court-Form Driven', detail: 'Uses actual court forms' },
-  { label: 'Attorney-Built', detail: 'Licensed in 8 states' },
-  { label: 'Free Calculators', detail: 'No account required' },
+  { label: 'Court-form driven', detail: 'Built around real legal workflows' },
+  { label: 'Plain English', detail: 'Clarity without the jargon wall' },
+  { label: 'Live products', detail: 'Use calculators, QDROs, and estate planning today' },
+  { label: 'More on the way', detail: 'New tools roll out in focused public releases' },
 ]
 
 const steps = [
-  { num: '01', title: 'Pick Your State', desc: 'Select your jurisdiction. We load that state\'s guidelines, formulas, and court-form requirements.' },
-  { num: '02', title: 'Enter Your Numbers', desc: 'Income, overnights, retirement accounts — plain-English questions, no legal jargon.' },
-  { num: '03', title: 'See the Full Picture', desc: 'Support calculations with future-value timelines. What $30K today means at age 62.' },
-  { num: '04', title: 'Download Results', desc: 'Export calculation summaries as PDFs for your attorney, mediator, or records.' },
+  { num: '01', title: 'Pick your state', desc: 'We load the right rules, formulas, and workflow details for your jurisdiction.' },
+  { num: '02', title: 'Answer plain questions', desc: 'Income, overnights, retirement accounts, family details, no legal-jargon obstacle course.' },
+  { num: '03', title: 'See clear outputs', desc: 'Calculations, timelines, and document workflows that show the practical next step.' },
+  { num: '04', title: 'Move forward faster', desc: 'Download results, start a product workflow, or bring cleaner information into attorney review.' },
 ]
 
 function ProductCard({
@@ -121,7 +120,7 @@ function ProductCard({
       </h3>
       <p className="mt-3 text-sm leading-relaxed text-slate-600">{product.description}</p>
       <div className="mt-5 flex items-center text-sm font-semibold transition-colors" style={{ color: product.color }}>
-        {product.live ? 'Get started' : product.badge === 'Public Alpha' ? 'Open public alpha' : product.badge === 'Free Beta' ? 'Open free beta' : 'Learn more'}
+        {product.live ? 'Get started' : product.badge === 'Public Alpha' ? 'Explore product' : product.badge === 'Free Beta' ? 'Open free beta' : 'Learn more'}
         <svg className="ml-1 h-4 w-4 transition-transform group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" /></svg>
       </div>
     </Link>
@@ -137,32 +136,29 @@ export default function HomePage() {
           <div className="max-w-3xl">
             <div className="mb-6 inline-flex items-center gap-2 rounded-full bg-teal-light px-4 py-1.5">
               <span className="h-2 w-2 animate-pulse rounded-full bg-green-500" />
-              <span className="text-sm font-semibold text-teal">Live Now — Free Calculators</span>
-            </div>
-            <div className="mb-4 inline-flex items-center gap-2 rounded-full bg-sky-50 px-4 py-1.5 text-sky-700">
-              <span className="h-2 w-2 rounded-full bg-sky-500" />
-              <span className="text-sm font-semibold">Public alpha across the broader platform</span>
+              <span className="text-sm font-semibold text-teal">Live now: calculators, QDRO, and estate planning beta</span>
             </div>
             <h1 className="font-[family-name:var(--font-space)] text-4xl font-bold leading-tight text-slate-900 sm:text-5xl lg:text-6xl">
-              Divorce is hard.<br />
-              <span className="text-teal">Your tools shouldn&rsquo;t be.</span>
+              Legal tools that help people
+              <br />
+              <span className="text-teal">get organized and move forward.</span>
             </h1>
             <p className="mt-6 max-w-2xl text-lg leading-relaxed text-slate-600 sm:text-xl">
-              The free child support calculator is live now. The broader platform is public alpha, so visitors can see what is shipping next while we tighten the workflows in public.
+              LexyAlgo makes divorce and family-law workflows easier to understand, from free calculators to guided document tools and retirement-division products. Start with what is live today, then follow the products that are rolling out next.
             </p>
             <div className="mt-8 flex flex-col gap-4 sm:flex-row">
               <Link
                 href="/#products"
                 className="inline-flex items-center justify-center rounded-2xl bg-primary-container px-8 py-4 font-semibold text-white shadow-lg shadow-primary-container/20 transition-all hover:bg-primary hover:shadow-xl hover:shadow-primary-container/30 active:scale-[0.98]"
               >
-                Find your solution
+                Explore products
                 <svg className="ml-2 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 8l4 4m0 0l-4 4m4-4H3" /></svg>
               </Link>
               <Link
                 href="/calculator"
                 className="inline-flex items-center justify-center rounded-2xl border-2 border-slate-200 px-8 py-4 font-semibold text-slate-700 transition-all hover:border-slate-300 hover:bg-slate-50"
               >
-                Open calculators
+                Start with calculators
               </Link>
             </div>
           </div>
@@ -182,106 +178,26 @@ export default function HomePage() {
         </div>
       </section>
 
-      <section className="py-20 sm:py-28">
-        <div className="mx-auto grid max-w-7xl grid-cols-1 items-center gap-16 px-4 sm:px-6 lg:grid-cols-2 lg:px-8">
-          <div>
-            <div className="mb-4 inline-flex items-center gap-2 rounded-full bg-teal-light px-3 py-1">
-              <span className="h-2 w-2 rounded-full bg-green-500" />
-              <span className="text-xs font-semibold uppercase tracking-wider text-teal">Available Now</span>
-            </div>
-            <h2 className="font-[family-name:var(--font-space)] text-3xl font-bold text-slate-900 sm:text-4xl">
-              Child Support Calculator
-            </h2>
-            <p className="mt-4 text-lg leading-relaxed text-slate-600">
-              State-specific child support guideline estimates with plain-English explanations so people can get a fast, useful starting point before they talk strategy.
-            </p>
-            <div className="mt-6 space-y-3">
-              {[
-                'Child support guideline calculations by state',
-                'Available across all 50 states plus DC',
-                'Plain-English explanations alongside every estimate',
-                'Fast starting point before attorney review',
-                'More calculators are on the roadmap',
-              ].map((item) => (
-                <div key={item} className="flex items-start gap-3">
-                  <div className="mt-0.5 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full bg-teal/10">
-                    <svg className="h-3 w-3 text-teal" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" /></svg>
-                  </div>
-                  <span className="text-sm text-slate-700">{item}</span>
-                </div>
-              ))}
-            </div>
-            <Link
-              href="/calculator"
-              className="mt-8 inline-flex items-center justify-center rounded-2xl bg-teal px-8 py-4 font-semibold text-white shadow-lg shadow-teal/20 transition-all hover:bg-[#12434D] active:scale-[0.98]"
-            >
-              Open calculators
-            </Link>
-          </div>
-          <div className="overflow-hidden rounded-2xl shadow-2xl ring-1 ring-slate-200/60">
-            <div className="flex items-center gap-1.5 border-b border-slate-200 bg-slate-100 px-4 py-2">
-              <div className="h-2 w-2 rounded-full bg-red-400/80" />
-              <div className="h-2 w-2 rounded-full bg-yellow-400/80" />
-              <div className="h-2 w-2 rounded-full bg-green-400/80" />
-              <div className="ml-3 flex h-4 max-w-[200px] flex-1 items-center rounded border border-slate-200 bg-white px-2">
-                <span className="text-[10px] text-slate-400">lexyalgo.com/calculator</span>
-              </div>
-            </div>
-            <Image
-              src="/screenshots/calculator-ct.png"
-              alt="Connecticut child support calculator — state-specific guidelines and future-value timeline"
-              width={800}
-              height={600}
-              className="block h-auto w-full"
-              priority
-            />
-          </div>
-        </div>
-      </section>
-
-      <section className="bg-slate-950 py-20 sm:py-28">
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-          <div className="mx-auto mb-16 max-w-2xl text-center">
-            <h2 className="font-[family-name:var(--font-space)] text-3xl font-bold text-white sm:text-4xl">
-              How it works
-            </h2>
-            <p className="mt-4 text-lg text-slate-400">
-              Four steps from confused to confident. No law degree required.
-            </p>
-          </div>
-
-          <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-4">
-            {steps.map((step) => (
-              <div key={step.num} className="relative">
-                <span className="font-[family-name:var(--font-space)] text-5xl font-bold text-slate-800">{step.num}</span>
-                <h3 className="mt-4 font-[family-name:var(--font-space)] text-lg font-bold text-white">{step.title}</h3>
-                <p className="mt-2 text-sm leading-relaxed text-slate-400">{step.desc}</p>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
       <section id="products" className="scroll-mt-24 py-20 sm:py-28">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
           <div className="mx-auto mb-16 max-w-2xl text-center">
-            <span className="text-sm font-semibold uppercase tracking-wider text-primary-container">The Platform</span>
+            <span className="text-sm font-semibold uppercase tracking-wider text-primary-container">The platform</span>
             <h2 className="mt-3 font-[family-name:var(--font-space)] text-3xl font-bold text-slate-900 sm:text-4xl">
-              Find the right path for your legal work
+              Start with the right product for the job
             </h2>
             <p className="mt-4 text-lg text-slate-600">
-              The child support calculator and QDRO services are live today. Divorce Forms, Asset Divider, and Co-Parent are shown publicly as alpha surfaces while we keep shipping. LexyFiling remains a coming-soon roadmap item.
+              Some parts of LexyAlgo are ready to use today, and others are visible as early product releases. Every page should make it clear what is live, what is in beta, and what is still on the roadmap.
             </p>
           </div>
 
           <div className="rounded-[2rem] border border-slate-200 bg-slate-50/70 p-6 sm:p-8">
             <div className="max-w-2xl">
-              <span className="text-sm font-semibold uppercase tracking-wider text-slate-500">Divorce &amp; family law</span>
+              <span className="text-sm font-semibold uppercase tracking-wider text-slate-500">Divorce and family law</span>
               <h3 className="mt-3 font-[family-name:var(--font-space)] text-2xl font-bold text-slate-900 sm:text-3xl">
-                One place for forms, calculations, negotiation, and filing
+                Calculations, forms, coordination, and filing in one product family
               </h3>
               <p className="mt-3 text-slate-600">
-                Start with calculators, move into QDRO work, then keep going through documents, asset division, co-parenting, and filing.
+                Use calculators now, start a QDRO order today, and explore the document, asset-division, and co-parenting products that are rolling out next.
               </p>
             </div>
             <div className="mt-8 grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
@@ -299,7 +215,7 @@ export default function HomePage() {
                   A separate lane for wills, trusts, and directives
                 </h3>
                 <p className="mt-4 max-w-2xl text-slate-700">
-                  Estate planning isn&rsquo;t a divorce add-on. It&rsquo;s its own product line for families who need trusts, wills, powers of attorney, and healthcare directives handled cleanly.
+                  Estate planning is its own product line for families who need trusts, wills, powers of attorney, and healthcare directives handled cleanly.
                 </p>
                 <div className="mt-6 flex flex-wrap gap-3 text-sm text-slate-700">
                   {['Living Trust', 'Will', 'Power of Attorney', 'Healthcare Directive'].map((item) => (
@@ -332,7 +248,7 @@ export default function HomePage() {
                   {estatePlanningProduct.description}
                 </p>
                 <div className="mt-6 border-l-4 border-[color:#7A5C1E] bg-[color:rgba(122,92,30,.08)] px-4 py-3 text-sm text-slate-700">
-                  Free beta access is live now, with the same plain-English clarity and guided workflow as the rest of LexyAlgo.
+                  Free beta access is available now, with guided flows and downloadable documents.
                 </div>
               </div>
             </div>
@@ -340,15 +256,95 @@ export default function HomePage() {
         </div>
       </section>
 
+      <section className="py-20 sm:py-28">
+        <div className="mx-auto grid max-w-7xl grid-cols-1 items-center gap-16 px-4 sm:px-6 lg:grid-cols-2 lg:px-8">
+          <div>
+            <div className="mb-4 inline-flex items-center gap-2 rounded-full bg-teal-light px-3 py-1">
+              <span className="h-2 w-2 rounded-full bg-green-500" />
+              <span className="text-xs font-semibold uppercase tracking-wider text-teal">Available now</span>
+            </div>
+            <h2 className="font-[family-name:var(--font-space)] text-3xl font-bold text-slate-900 sm:text-4xl">
+              Child Support Calculator
+            </h2>
+            <p className="mt-4 text-lg leading-relaxed text-slate-600">
+              State-specific child support estimates with plain-English explanations, so people can get a fast, useful starting point before they decide what comes next.
+            </p>
+            <div className="mt-6 space-y-3">
+              {[
+                'Child support guideline calculations by state',
+                'Available across all 50 states plus DC',
+                'Plain-English explanations alongside every estimate',
+                'Fast starting point before attorney review',
+                'Downloadable summaries for your records',
+              ].map((item) => (
+                <div key={item} className="flex items-start gap-3">
+                  <div className="mt-0.5 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full bg-teal/10">
+                    <svg className="h-3 w-3 text-teal" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" /></svg>
+                  </div>
+                  <span className="text-sm text-slate-700">{item}</span>
+                </div>
+              ))}
+            </div>
+            <Link
+              href="/calculator"
+              className="mt-8 inline-flex items-center justify-center rounded-2xl bg-teal px-8 py-4 font-semibold text-white shadow-lg shadow-teal/20 transition-all hover:bg-[#12434D] active:scale-[0.98]"
+            >
+              Open calculators
+            </Link>
+          </div>
+          <div className="overflow-hidden rounded-2xl shadow-2xl ring-1 ring-slate-200/60">
+            <div className="flex items-center gap-1.5 border-b border-slate-200 bg-slate-100 px-4 py-2">
+              <div className="h-2 w-2 rounded-full bg-red-400/80" />
+              <div className="h-2 w-2 rounded-full bg-yellow-400/80" />
+              <div className="h-2 w-2 rounded-full bg-green-400/80" />
+              <div className="ml-3 flex h-4 max-w-[200px] flex-1 items-center rounded border border-slate-200 bg-white px-2">
+                <span className="text-[10px] text-slate-400">lexyalgo.com/calculator</span>
+              </div>
+            </div>
+            <Image
+              src="/screenshots/calculator-ct.png"
+              alt="Connecticut child support calculator with state-specific guidelines and future-value timeline"
+              width={800}
+              height={600}
+              className="block h-auto w-full"
+              priority
+            />
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-slate-950 py-20 sm:py-28">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <div className="mx-auto mb-16 max-w-2xl text-center">
+            <h2 className="font-[family-name:var(--font-space)] text-3xl font-bold text-white sm:text-4xl">
+              How it works
+            </h2>
+            <p className="mt-4 text-lg text-slate-400">
+              A simpler path from confusion to a useful next step.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-4">
+            {steps.map((step) => (
+              <div key={step.num} className="relative">
+                <span className="font-[family-name:var(--font-space)] text-5xl font-bold text-slate-800">{step.num}</span>
+                <h3 className="mt-4 font-[family-name:var(--font-space)] text-lg font-bold text-white">{step.title}</h3>
+                <p className="mt-2 text-sm leading-relaxed text-slate-400">{step.desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
       <section className="bg-slate-50 py-20 sm:py-28">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
           <div className="mx-auto mb-12 max-w-2xl text-center">
-            <span className="text-sm font-semibold uppercase tracking-wider text-teal">Product Previews</span>
+            <span className="text-sm font-semibold uppercase tracking-wider text-teal">Product previews</span>
             <h2 className="mt-3 font-[family-name:var(--font-space)] text-3xl font-bold text-slate-900 sm:text-4xl">
-              See it in action
+              See the product family taking shape
             </h2>
             <p className="mt-4 text-lg text-slate-600">
-              We&rsquo;re building real tools, not slide decks. Here&rsquo;s what&rsquo;s taking shape.
+              Real interfaces, real workflows, and honest labels for what is live today versus still emerging.
             </p>
           </div>
           <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
@@ -363,13 +359,13 @@ export default function HomePage() {
               </div>
               <Image
                 src="/screenshots/v2-app-homepage.png"
-                alt="LexyAlgo V2 App — Divorce Forms and Asset Divider"
+                alt="LexyAlgo app preview for divorce forms and asset division"
                 width={800}
                 height={540}
                 className="block h-auto w-full"
               />
               <div className="border-t border-slate-100 bg-white px-4 py-2">
-                <p className="text-xs font-semibold text-slate-700">Divorce Forms &amp; Asset Divider</p>
+                <p className="text-xs font-semibold text-slate-700">Divorce Forms and Asset Divider</p>
               </div>
             </div>
             <div className="overflow-hidden rounded-2xl shadow-xl ring-1 ring-slate-200/80">
@@ -403,7 +399,7 @@ export default function HomePage() {
               </div>
               <Image
                 src="/screenshots/coparent-app.png"
-                alt="Co-Parent App — login and dashboard at kid.lexyalgo.com"
+                alt="Co-Parent app preview"
                 width={800}
                 height={540}
                 className="block h-auto w-full"
@@ -423,13 +419,13 @@ export default function HomePage() {
               </div>
               <Image
                 src="/screenshots/filing-app.png"
-                alt="LexyFiling E-Filing App — court submission portal"
+                alt="LexyFiling product concept preview"
                 width={800}
                 height={540}
                 className="block h-auto w-full"
               />
               <div className="border-t border-slate-100 bg-white px-4 py-2">
-                <p className="text-xs font-semibold text-slate-700">LexyFiling</p>
+                <p className="text-xs font-semibold text-slate-700">LexyFiling roadmap preview</p>
               </div>
             </div>
           </div>
@@ -439,13 +435,24 @@ export default function HomePage() {
       <section className="bg-peach">
         <div className="mx-auto max-w-7xl px-4 py-16 text-center sm:px-6 sm:py-20 lg:px-8">
           <h2 className="font-[family-name:var(--font-space)] text-3xl font-bold text-slate-900 sm:text-4xl">
-            Explore the platform as it ships
+            Start with what is live today
           </h2>
           <p className="mx-auto mt-4 max-w-xl text-lg text-slate-700">
-            Free calculators are live today. Divorce Forms, Asset Divider, and Co-Parent are exposed on the main site for public testing, while LexyFiling stays marked coming soon.
+            Open the free calculators, start a QDRO order, or explore estate planning beta without hunting through mixed signals.
           </p>
-          <div className="mx-auto mt-8 max-w-xl">
-            <WaitlistForm product="LexyAlgo — All Products" accentColor="#B02700" accentHover="#861B00" compact />
+          <div className="mt-8 flex flex-col justify-center gap-4 sm:flex-row">
+            <Link
+              href="/calculator"
+              className="inline-flex items-center justify-center rounded-2xl bg-ember px-8 py-4 font-semibold text-white transition-all hover:bg-[#861B00] active:scale-[0.98]"
+            >
+              Open calculators
+            </Link>
+            <Link
+              href="/pricing"
+              className="inline-flex items-center justify-center rounded-2xl border-2 border-slate-300 px-8 py-4 font-semibold text-slate-700 transition-all hover:border-slate-400 hover:bg-white"
+            >
+              View pricing
+            </Link>
           </div>
         </div>
       </section>

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -210,6 +210,14 @@ export default function PricingPage() {
           </div>
         </div>
       </section>
+
+      <section className="py-12">
+        <div className="mx-auto max-w-3xl px-4 text-center sm:px-6 lg:px-8">
+          <p className="text-xs text-slate-400">
+            LexyAlgo provides document preparation assistance and calculation tools only. It does not constitute legal advice. Consult a licensed attorney for legal guidance specific to your situation.
+          </p>
+        </div>
+      </section>
     </>
   )
 }

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -4,7 +4,7 @@ import { WaitlistForm } from '@/components/WaitlistForm'
 
 export const metadata: Metadata = {
   title: 'Pricing — LexyAlgo',
-  description: 'Free tier for calculators, Asset Divider, and estate planning beta. Premium reserved for valuation tools and deeper analysis.',
+  description: 'Free calculators, live QDRO pricing, and honest rollout pricing for the rest of the LexyAlgo product line.',
 }
 
 const tiers = [
@@ -12,36 +12,36 @@ const tiers = [
     name: 'Free',
     price: '$0',
     period: 'forever',
-    description: 'The core LexyAlgo access tier for people who need clarity before they need expensive help.',
+    description: 'Start here for calculators, core planning tools, and estate-planning beta access.',
     features: [
       'Child support calculators (all states)',
       'Retirement division calculators',
-      'Asset Divider access',
+      'Asset Divider preview access',
       'Future value timelines',
       'Coverture fraction calculations',
       'Plain-English explanations',
       'PDF export of calculations',
       'Estate planning beta access',
     ],
-    cta: 'Start Free',
+    cta: 'Start free',
     ctaHref: '/calculator',
     highlight: true,
     available: true,
   },
   {
-    name: 'Premium Valuation',
-    price: '$50+',
-    period: 'starting price',
-    description: 'Reserved for valuation-heavy workflows where deeper financial analysis creates real value.',
+    name: 'Premium valuation',
+    price: 'TBD',
+    period: '',
+    description: 'Reserved for higher-complexity valuation workflows. We are not publishing a fixed public price until that release is final.',
     features: [
       'Everything in Free',
-      'Advanced business / asset valuation workflows',
+      'Advanced business and asset valuation workflows',
       'Premium retirement valuation tools',
       'Scenario comparison for higher-complexity assets',
       'Attorney-ready export packages',
       'Priority access to new valuation releases',
     ],
-    cta: 'Join Waitlist',
+    cta: 'Join waitlist',
     ctaHref: '#waitlist',
     highlight: false,
     available: false,
@@ -50,17 +50,17 @@ const tiers = [
     name: 'Co-Parent',
     price: 'TBD',
     period: '',
-    description: 'Shared calendar, expenses, and communication — a separate product track for ongoing family coordination.',
+    description: 'Shared calendar, expenses, and communication for ongoing family coordination.',
     features: [
       'Parenting time calendar',
-      'Expense tracking & splitting',
+      'Expense tracking and splitting',
       'In-app messaging',
       'Holiday scheduling',
       'Decision tracking',
       'Document storage',
     ],
-    cta: 'Contact Us',
-    ctaHref: '/contact',
+    cta: 'Explore product',
+    ctaHref: '/products/co-parent',
     highlight: false,
     available: false,
   },
@@ -72,35 +72,35 @@ export default function PricingPage() {
   return (
     <>
       <section className="bg-gradient-to-b from-surface to-white py-20 sm:py-28">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-          <h1 className="font-[family-name:var(--font-space)] text-4xl sm:text-5xl font-bold text-slate-900">
-            Simple pricing that starts with free
+        <div className="mx-auto max-w-7xl px-4 text-center sm:px-6 lg:px-8">
+          <h1 className="font-[family-name:var(--font-space)] text-4xl font-bold text-slate-900 sm:text-5xl">
+            Straightforward pricing, with free where it should be free
           </h1>
-          <p className="mt-4 text-lg text-slate-600 max-w-3xl mx-auto">
-            Asset Divider is now in the free tier. Premium is reserved for valuation tools and deeper analysis — not for basic access to clarity.
+          <p className="mx-auto mt-4 max-w-3xl text-lg text-slate-600">
+            Use calculators and estate-planning beta without paying for basic clarity. When a product has live pricing, we show it plainly. When it does not, we say that too.
           </p>
         </div>
       </section>
 
-      <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 -mt-8 mb-20">
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+      <section className="mx-auto -mt-8 mb-20 max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
           {tiers.map((tier) => (
             <div key={tier.name}
               className={`rounded-2xl p-8 ${
                 tier.highlight
                   ? 'bg-slate-950 text-white ring-2 ring-primary-container shadow-2xl shadow-primary-container/10'
-                  : 'bg-white border border-slate-200'
+                  : 'border border-slate-200 bg-white'
               }`}
             >
               <div className="flex items-center justify-between gap-3">
-                <h3 className="font-[family-name:var(--font-space)] font-bold text-xl">{tier.name}</h3>
+                <h3 className="font-[family-name:var(--font-space)] text-xl font-bold">{tier.name}</h3>
                 {!tier.available && (
-                  <span className={`text-xs font-medium px-2.5 py-1 rounded-full ${
+                  <span className={`rounded-full px-2.5 py-1 text-xs font-medium ${
                     tier.highlight ? 'bg-primary-container/20 text-[#FFB4A3]' : 'bg-slate-100 text-slate-600'
-                  }`}>Coming Soon</span>
+                  }`}>Coming soon</span>
                 )}
                 {tier.available && (
-                  <span className="text-xs font-medium px-2.5 py-1 rounded-full bg-[#FFB4A3]/20 text-[#FFB4A3]">Available</span>
+                  <span className="rounded-full bg-[#FFB4A3]/20 px-2.5 py-1 text-xs font-medium text-[#FFB4A3]">Available</span>
                 )}
               </div>
               <div className="mt-4">
@@ -110,51 +110,45 @@ export default function PricingPage() {
               <p className={`mt-3 text-sm ${tier.highlight ? 'text-slate-300' : 'text-slate-600'}`}>{tier.description}</p>
               <ul className="mt-6 space-y-3">
                 {tier.features.map((feature) => (
-                  <li key={feature} className="flex gap-3 items-start">
-                    <svg className={`w-5 h-5 flex-shrink-0 ${tier.highlight ? 'text-[#FFB4A3]' : 'text-primary-container'}`} fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" /></svg>
+                  <li key={feature} className="flex items-start gap-3">
+                    <svg className={`h-5 w-5 flex-shrink-0 ${tier.highlight ? 'text-[#FFB4A3]' : 'text-primary-container'}`} fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" /></svg>
                     <span className={`text-sm ${tier.highlight ? 'text-slate-300' : 'text-slate-600'}`}>{feature}</span>
                   </li>
                 ))}
               </ul>
               <div className="mt-8">
-                {tier.available ? (
-                  <Link href={tier.ctaHref}
-                    className="block text-center font-semibold py-3 px-6 rounded-xl transition-all active:scale-[0.98] bg-primary-container text-white hover:bg-primary shadow-sm"
-                  >
-                    {tier.cta}
-                  </Link>
-                ) : (
-                  <Link href={tier.ctaHref}
-                    className={`block text-center font-semibold py-3 px-6 rounded-xl transition-all active:scale-[0.98] ${
-                      tier.highlight
+                <Link href={tier.ctaHref}
+                  className={`block rounded-xl px-6 py-3 text-center font-semibold transition-all active:scale-[0.98] ${
+                    tier.highlight
+                      ? 'bg-primary-container text-white shadow-sm hover:bg-primary'
+                      : tier.available
                         ? 'bg-primary-container text-white hover:bg-primary'
                         : 'border-2 border-slate-200 text-slate-700 hover:border-slate-300'
-                    }`}
-                  >
-                    {tier.cta}
-                  </Link>
-                )}
+                  }`}
+                >
+                  {tier.cta}
+                </Link>
               </div>
             </div>
           ))}
         </div>
       </section>
 
-      <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 mb-20">
+      <section className="mx-auto mb-20 max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="rounded-3xl border border-[#E3BEB6] bg-[#FFEDE8] p-8 sm:p-10">
           <div className="grid gap-8 lg:grid-cols-[1.1fr_0.9fr] lg:items-center">
             <div>
-              <p className="text-sm font-semibold uppercase tracking-[0.2em] text-primary-container">Prominently free right now</p>
+              <p className="text-sm font-semibold uppercase tracking-[0.2em] text-primary-container">Free right now</p>
               <h2 className="mt-3 font-[family-name:var(--font-space)] text-3xl font-bold text-slate-900">
                 Try LexyAlgo estate planning on Docassemble
               </h2>
-              <p className="mt-4 text-slate-700 max-w-2xl">
-                Generate a living trust, will, power of attorney, and healthcare directive during beta at no cost. It&rsquo;s one of the fastest ways to experience the platform today.
+              <p className="mt-4 max-w-2xl text-slate-700">
+                Generate a living trust, will, power of attorney, and healthcare directive during beta at no cost. It is one of the clearest ways to experience the product today.
               </p>
             </div>
             <div className="flex flex-col gap-4 sm:flex-row lg:justify-end">
               <a href={estatePlanningUrl} className="inline-flex items-center justify-center rounded-2xl bg-primary-container px-8 py-4 font-semibold text-white transition-all hover:bg-primary active:scale-[0.98]">
-                Try it now free
+                Try it free
               </a>
               <Link href="/products/estate-planning" className="inline-flex items-center justify-center rounded-2xl border-2 border-white bg-white/70 px-8 py-4 font-semibold text-slate-700 transition-all hover:bg-white">
                 Learn more
@@ -164,64 +158,56 @@ export default function PricingPage() {
         </div>
       </section>
 
-      <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 mb-20">
-        <div className="text-center mb-12">
-          <div className="inline-flex items-center gap-2 bg-green-50 px-4 py-1.5 rounded-full mb-4">
-            <span className="w-2 h-2 rounded-full bg-green-500" />
-            <span className="text-sm font-semibold text-green-700">Available Now</span>
+      <section className="mx-auto mb-20 max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="mb-12 text-center">
+          <div className="mb-4 inline-flex items-center gap-2 rounded-full bg-green-50 px-4 py-1.5">
+            <span className="h-2 w-2 rounded-full bg-green-500" />
+            <span className="text-sm font-semibold text-green-700">Available now</span>
           </div>
           <h2 className="font-[family-name:var(--font-space)] text-3xl font-bold text-slate-900">
             QDRO Generator
           </h2>
-          <p className="mt-3 text-lg text-slate-600 max-w-2xl mx-auto">
+          <p className="mx-auto mt-3 max-w-2xl text-lg text-slate-600">
             Generate a Qualified Domestic Relations Order for retirement plan division in divorce. Supports nearly one million plans nationwide.
           </p>
         </div>
-        <div className="max-w-md mx-auto">
-          <div className="rounded-2xl bg-slate-950 text-white p-10 text-center ring-2 ring-ember">
-            <span className="text-xs font-medium px-2.5 py-1 rounded-full bg-green-100 text-green-700">Available Now</span>
+        <div className="mx-auto max-w-md">
+          <div className="rounded-2xl bg-slate-950 p-10 text-center text-white ring-2 ring-ember">
+            <span className="rounded-full bg-green-100 px-2.5 py-1 text-xs font-medium text-green-700">Available now</span>
             <div className="mt-6">
               <span className="font-[family-name:var(--font-space)] text-5xl font-bold">$100</span>
               <span className="ml-1 text-sm text-slate-400">per order</span>
             </div>
-            <p className="mt-4 text-slate-300 text-sm">
-              Answer the intake questions, we generate the order for your retirement plan.
+            <p className="mt-4 text-sm text-slate-300">
+              One order, one flat price. Answer the intake questions and generate the document for your plan.
             </p>
-            <ul className="mt-6 space-y-3 text-left max-w-xs mx-auto">
-              {['Supports nearly 1 million plans', 'Defined benefit & defined contribution', 'Answer questions, get your order', 'Download as PDF'].map((f) => (
-                <li key={f} className="flex gap-3 items-start">
-                  <svg className="w-5 h-5 flex-shrink-0 text-[#FFB4A3]" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" /></svg>
+            <ul className="mx-auto mt-6 max-w-xs space-y-3 text-left">
+              {['Supports nearly 1 million plans', 'Defined benefit and defined contribution', 'Answer questions, get your order', 'Download as PDF'].map((f) => (
+                <li key={f} className="flex items-start gap-3">
+                  <svg className="h-5 w-5 flex-shrink-0 text-[#FFB4A3]" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" /></svg>
                   <span className="text-sm text-slate-300">{f}</span>
                 </li>
               ))}
             </ul>
             <div className="mt-8">
-              <a href="https://doc.lexyalgo.com" className="block text-center font-semibold py-3 px-6 rounded-xl bg-ember text-white hover:bg-[#861B00] transition-all active:scale-[0.98]">
+              <a href="https://doc.lexyalgo.com" className="block rounded-xl bg-ember px-6 py-3 text-center font-semibold text-white transition-all hover:bg-[#861B00] active:scale-[0.98]">
                 Generate a QDRO
               </a>
             </div>
           </div>
         </div>
-        <p className="text-center text-sm text-slate-500 mt-6">
+        <p className="mt-6 text-center text-sm text-slate-500">
           <Link href="/products/qdro" className="text-ember hover:underline">Learn more about QDRO Generator →</Link>
         </p>
       </section>
 
       <section id="waitlist" className="bg-peach py-16 sm:py-20">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-          <h2 className="font-[family-name:var(--font-space)] text-3xl font-bold text-slate-900">Get notified at launch</h2>
-          <p className="mt-4 text-slate-700 max-w-lg mx-auto">Premium valuation tools and Co-Parent are coming soon. Join the waitlist — no spam, just launch updates.</p>
-          <div className="mt-8 max-w-xl mx-auto">
+        <div className="mx-auto max-w-7xl px-4 text-center sm:px-6 lg:px-8">
+          <h2 className="font-[family-name:var(--font-space)] text-3xl font-bold text-slate-900">Get notified when new paid tools launch</h2>
+          <p className="mx-auto mt-4 max-w-lg text-slate-700">Premium valuation tools and the full Co-Parent release are still coming soon. Join the waitlist for launch updates only.</p>
+          <div className="mx-auto mt-8 max-w-xl">
             <WaitlistForm product="LexyAlgo Premium" accentColor="#B02700" accentHover="#861B00" compact />
           </div>
-        </div>
-      </section>
-
-      <section className="py-12">
-        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-          <p className="text-xs text-slate-400">
-            LexyAlgo provides document preparation assistance and calculation tools only. It does not constitute legal advice. Consult a licensed attorney for legal guidance specific to your situation.
-          </p>
         </div>
       </section>
     </>

--- a/src/app/products/asset-divider/page.tsx
+++ b/src/app/products/asset-divider/page.tsx
@@ -34,7 +34,7 @@ export default function AssetDividerPage() {
                 Divide property without the heartache
               </h1>
               <p className="mt-6 text-lg text-slate-600 leading-relaxed">
-                A visual workspace, now visible in public alpha, that turns the most stressful part of divorce, splitting everything you built together, into clear, fair decisions. Every trade-off framed as a gain.
+                A visual workspace for weighing tradeoffs, dividing property, and seeing balance in real time. Asset Divider is available as an early release while the workflow keeps improving.
               </p>
               <div className="mt-8 flex flex-col sm:flex-row gap-4">
                 <a href={PUBLIC_ALPHA_URL}
@@ -54,10 +54,10 @@ export default function AssetDividerPage() {
                 Public Alpha Access
               </div>
               <h2 className="mt-5 font-[family-name:var(--font-space)] text-2xl font-bold text-slate-900">
-                This workspace is exposed for public testing
+                Explore the current release
               </h2>
               <p className="mt-3 text-sm leading-relaxed text-slate-600">
-                Asset Divider is no longer buried behind a waitlist on the marketing site. People can reach the alpha directly from here.
+                People can reach Asset Divider directly from the site and see how the product experience is taking shape.
               </p>
               <a href={PUBLIC_ALPHA_URL}
                 className="mt-8 inline-flex w-full items-center justify-center rounded-2xl bg-ember px-6 py-4 text-center font-semibold text-white transition-all hover:bg-[#861B00] active:scale-[0.98]"
@@ -102,17 +102,17 @@ export default function AssetDividerPage() {
       <section className="bg-peach py-16 sm:py-20 text-center">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <h2 className="font-[family-name:var(--font-space)] text-3xl font-bold text-slate-900">Test Asset Divider now</h2>
-          <p className="mt-4 text-slate-700 max-w-lg mx-auto">Public alpha is open on the site. Get into the workflow and pressure-test the property split experience.</p>
+          <p className="mt-4 max-w-lg mx-auto text-slate-700">Open the product, walk through the property-split workflow, and see how balance updates in real time.</p>
           <div className="mt-8 flex flex-col sm:flex-row gap-4 justify-center">
             <a href={PUBLIC_ALPHA_URL}
               className="inline-flex items-center justify-center bg-ember text-white font-semibold px-8 py-4 rounded-2xl hover:bg-[#861B00] transition-all shadow-lg shadow-ember/20 active:scale-[0.98]"
             >
               Open Public Alpha
             </a>
-            <Link href="/contact"
+            <Link href="/calculator"
               className="inline-flex items-center justify-center border-2 border-slate-300 text-slate-700 font-semibold px-8 py-4 rounded-2xl hover:border-slate-400 hover:bg-white transition-all"
             >
-              Send feedback
+              Open calculators
             </Link>
           </div>
         </div>

--- a/src/app/products/co-parent/page.tsx
+++ b/src/app/products/co-parent/page.tsx
@@ -34,7 +34,7 @@ export default function CoParentPage() {
                 Parenting together, separately
               </h1>
               <p className="mt-6 text-lg text-slate-600 leading-relaxed">
-                A co-parenting platform built around positive parenting time, not conflict. It is now visible as a public alpha, with shared calendars, expense tracking, and communication tools that keep the focus on your children.
+                A co-parenting platform built around positive parenting time, not conflict, with shared calendars, expense tracking, and communication tools that keep the focus on your children.
               </p>
               <div className="mt-8 flex flex-col sm:flex-row gap-4">
                 <a href={PUBLIC_ALPHA_URL}
@@ -54,10 +54,10 @@ export default function CoParentPage() {
                 Public Alpha Access
               </div>
               <h2 className="mt-5 font-[family-name:var(--font-space)] text-2xl font-bold text-slate-900">
-                Co-Parent is exposed from the site
+                Explore the current release
               </h2>
               <p className="mt-3 text-sm leading-relaxed text-slate-600">
-                Visitors can now reach the current co-parenting alpha directly from the product page instead of hitting a waitlist wall first.
+                Visitors can reach the current Co-Parent release directly from the product page instead of hitting a waitlist wall first.
               </p>
               <a href={PUBLIC_ALPHA_URL}
                 className="mt-8 inline-flex w-full items-center justify-center rounded-2xl bg-sage px-6 py-4 text-center font-semibold text-white transition-all hover:bg-[#1F4D38] active:scale-[0.98]"
@@ -115,17 +115,17 @@ export default function CoParentPage() {
       <section className="bg-peach py-16 sm:py-20 text-center">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <h2 className="font-[family-name:var(--font-space)] text-3xl font-bold text-slate-900">Test Co-Parent now</h2>
-          <p className="mt-4 text-slate-700 max-w-lg mx-auto">The current alpha is reachable from the site. Open it, log in, and pressure-test the parenting workflow.</p>
+          <p className="mt-4 max-w-lg mx-auto text-slate-700">Open the current release, log in, and see how the parenting workflow is designed to reduce friction.</p>
           <div className="mt-8 flex flex-col sm:flex-row gap-4 justify-center">
             <a href={PUBLIC_ALPHA_URL}
               className="inline-flex items-center justify-center bg-sage text-white font-semibold px-8 py-4 rounded-2xl hover:bg-[#1F4D38] transition-all shadow-lg shadow-sage/20 active:scale-[0.98]"
             >
               Open Public Alpha
             </a>
-            <Link href="/contact"
+            <Link href="/pricing"
               className="inline-flex items-center justify-center border-2 border-slate-300 text-slate-700 font-semibold px-8 py-4 rounded-2xl hover:border-slate-400 hover:bg-white transition-all"
             >
-              Send feedback
+              View pricing
             </Link>
           </div>
         </div>

--- a/src/app/products/divorce/page.tsx
+++ b/src/app/products/divorce/page.tsx
@@ -50,7 +50,7 @@ export default function DivorcePage() {
                 </Link>
               </div>
               <p className="mt-4 text-xs text-slate-500">
-                Public alpha, open for real-world testing while we tighten the workflows in public.
+                Early product release, open for hands-on testing while state coverage and workflow depth continue to expand.
               </p>
             </div>
             <div className="rounded-3xl border border-[#2B4580]/10 bg-white p-8 shadow-xl shadow-[#2B4580]/10">
@@ -58,10 +58,10 @@ export default function DivorcePage() {
                 Public Alpha Access
               </div>
               <h2 className="mt-5 font-[family-name:var(--font-space)] text-2xl font-bold text-slate-900">
-                The tool is out on the site now
+                Explore the current release
               </h2>
               <p className="mt-3 text-sm leading-relaxed text-slate-600">
-                We are exposing Divorce Forms directly so the public can test the product while we keep expanding the state coverage and workflow depth.
+                Divorce Forms is available for hands-on testing now, with more state coverage and workflow depth still in progress.
               </p>
               <ul className="mt-6 space-y-3 text-sm text-slate-700">
                 {['Public alpha is live', 'Court-form-driven workflow', 'CT and CA lead the rollout'].map((item) => (
@@ -125,17 +125,17 @@ export default function DivorcePage() {
       <section className="bg-[#E8EEF8] py-16 sm:py-20 text-center">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <h2 className="font-[family-name:var(--font-space)] text-3xl font-bold text-slate-900">Test Divorce Forms now</h2>
-          <p className="mt-4 text-slate-700 max-w-lg mx-auto">Public alpha is open. Run the workflow, pressure-test it, and tell us where it breaks.</p>
+          <p className="mt-4 max-w-lg mx-auto text-slate-700">Open the current release, walk through the workflow, and see how LexyAlgo handles document prep today.</p>
           <div className="mt-8 flex flex-col sm:flex-row gap-4 justify-center">
             <a href={PUBLIC_ALPHA_URL}
               className="inline-flex items-center justify-center bg-[#2B4580] text-white font-semibold px-8 py-4 rounded-2xl hover:bg-[#1C305A] transition-all shadow-lg shadow-[#2B4580]/20 active:scale-[0.98]"
             >
               Open Public Alpha
             </a>
-            <Link href="/contact"
+            <Link href="/pricing"
               className="inline-flex items-center justify-center border-2 border-slate-300 text-slate-700 font-semibold px-8 py-4 rounded-2xl hover:border-slate-400 hover:bg-white transition-all"
             >
-              Send feedback
+              View pricing
             </Link>
           </div>
         </div>

--- a/src/app/products/estate-planning/page.tsx
+++ b/src/app/products/estate-planning/page.tsx
@@ -53,10 +53,10 @@ export default function EstatePlanningPage() {
                 Try It Now — FREE
                 <svg className="ml-2 w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 8l4 4m0 0l-4 4m4-4H3" /></svg>
               </a>
-              <Link href="/contact"
+              <Link href="/pricing"
                 className="inline-flex items-center justify-center border-2 border-slate-200 text-slate-700 font-semibold px-8 py-4 rounded-2xl hover:border-slate-300 hover:bg-slate-50 transition-all"
               >
-                Questions? Contact Us
+                See pricing
               </Link>
             </div>
             <p className="mt-4 text-xs text-slate-500">
@@ -128,10 +128,10 @@ export default function EstatePlanningPage() {
             >
               Try It Now — FREE
             </a>
-            <Link href="/contact"
+            <Link href="/pricing"
               className="inline-flex items-center justify-center border-2 border-slate-300 text-slate-700 font-semibold px-8 py-4 rounded-2xl hover:border-slate-400 hover:bg-white transition-all"
             >
-              Questions? Contact Us
+              See pricing
             </Link>
           </div>
         </div>

--- a/src/app/products/estate-planning/page.tsx
+++ b/src/app/products/estate-planning/page.tsx
@@ -1,5 +1,4 @@
 import Link from 'next/link'
-import Image from 'next/image'
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
@@ -27,7 +26,6 @@ const steps = [
 export default function EstatePlanningPage() {
   return (
     <>
-      {/* Hero */}
       <section className="bg-gradient-to-br from-[#FAF2DC] via-white to-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20 sm:py-28">
           <div className="max-w-3xl">
@@ -66,7 +64,6 @@ export default function EstatePlanningPage() {
         </div>
       </section>
 
-      {/* How it works */}
       <section className="bg-slate-950 py-20">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center max-w-2xl mx-auto mb-16">
@@ -87,7 +84,6 @@ export default function EstatePlanningPage() {
         </div>
       </section>
 
-      {/* Features grid */}
       <section className="py-20">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <h2 className="font-[family-name:var(--font-space)] text-3xl font-bold text-slate-900 text-center mb-16">Four documents, one intake</h2>
@@ -105,7 +101,6 @@ export default function EstatePlanningPage() {
         </div>
       </section>
 
-      {/* Beta disclaimer */}
       <section className="py-12 bg-slate-50">
         <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <div className="inline-flex items-center gap-2 mb-4">
@@ -117,7 +112,6 @@ export default function EstatePlanningPage() {
         </div>
       </section>
 
-      {/* Bottom CTA */}
       <section className="bg-[#FAF2DC] py-16 sm:py-20 text-center">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <h2 className="font-[family-name:var(--font-space)] text-3xl font-bold text-slate-900">Protect your family. Start now.</h2>
@@ -131,7 +125,7 @@ export default function EstatePlanningPage() {
             <Link href="/pricing"
               className="inline-flex items-center justify-center border-2 border-slate-300 text-slate-700 font-semibold px-8 py-4 rounded-2xl hover:border-slate-400 hover:bg-white transition-all"
             >
-              See pricing
+              Compare plans
             </Link>
           </div>
         </div>

--- a/src/app/products/qdro/page.tsx
+++ b/src/app/products/qdro/page.tsx
@@ -9,7 +9,6 @@ export const metadata: Metadata = {
 export default function QdroPage() {
   return (
     <>
-      {/* Hero */}
       <section className="bg-gradient-to-br from-bronze-light via-white to-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20 sm:py-28">
           <div className="max-w-3xl">
@@ -45,11 +44,10 @@ export default function QdroPage() {
         </div>
       </section>
 
-      {/* No screenshot — QDRO generator lives at doc.lexyalgo.com (Docassemble) */}
       <section className="py-10 sm:py-14">
         <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="rounded-2xl bg-[#F5EDE5] border border-[#8B5E3C]/15 p-8 text-center">
-            <p className="text-sm font-semibold text-[#8B5E3C] uppercase tracking-wider mb-2">Available Now</p>
+            <p className="text-sm font-semibold text-[#8B5E3C] uppercase tracking-wider mb-2">Available now</p>
             <p className="text-slate-700 leading-relaxed">
               The QDRO generator is live at{' '}
               <a href="https://doc.lexyalgo.com" className="font-semibold text-[#8B5E3C] underline underline-offset-2 hover:text-[#6F4A2E]">
@@ -61,7 +59,6 @@ export default function QdroPage() {
         </div>
       </section>
 
-      {/* Simple pricing */}
       <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 mb-20">
         <div className="max-w-xl mx-auto">
           <div className="rounded-2xl bg-slate-950 text-white p-10 text-center ring-2 ring-bronze">
@@ -97,7 +94,6 @@ export default function QdroPage() {
         </div>
       </section>
 
-      {/* What is a QDRO */}
       <section className="py-20">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <h2 className="font-[family-name:var(--font-space)] text-3xl font-bold text-slate-900 text-center mb-16">What is a QDRO?</h2>
@@ -117,7 +113,6 @@ export default function QdroPage() {
         </div>
       </section>
 
-      {/* How it works */}
       <section className="bg-slate-950 py-20">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center max-w-2xl mx-auto mb-16">
@@ -142,7 +137,6 @@ export default function QdroPage() {
         </div>
       </section>
 
-      {/* Disclaimer */}
       <section className="py-12 bg-slate-50">
         <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <p className="text-sm text-slate-500">
@@ -151,7 +145,6 @@ export default function QdroPage() {
         </div>
       </section>
 
-      {/* Bottom CTA */}
       <section className="bg-bronze-light py-16 sm:py-20 text-center">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <h2 className="font-[family-name:var(--font-space)] text-3xl font-bold text-slate-900">Ready to divide the retirement plan?</h2>

--- a/src/app/products/qdro/page.tsx
+++ b/src/app/products/qdro/page.tsx
@@ -35,10 +35,10 @@ export default function QdroPage() {
                 Generate a QDRO
                 <svg className="ml-2 w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 8l4 4m0 0l-4 4m4-4H3" /></svg>
               </a>
-              <Link href="/contact"
+              <Link href="/pricing"
                 className="inline-flex items-center justify-center border-2 border-slate-200 text-slate-700 font-semibold px-8 py-4 rounded-2xl hover:border-slate-300 hover:bg-slate-50 transition-all"
               >
-                Questions? Contact Us
+                See pricing
               </Link>
             </div>
           </div>
@@ -162,10 +162,10 @@ export default function QdroPage() {
             >
               Generate a QDRO
             </a>
-            <Link href="/contact"
+            <Link href="/pricing"
               className="inline-flex items-center justify-center border-2 border-slate-300 text-slate-700 font-semibold px-8 py-4 rounded-2xl hover:border-slate-400 hover:bg-white transition-all"
             >
-              Questions? Contact Us
+              Review pricing
             </Link>
           </div>
         </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -43,8 +43,8 @@ export function Footer() {
             <Link href="/" className="font-[family-name:var(--font-space)] font-bold text-xl text-white tracking-tight">
               LEXY <span className="text-slate-600 font-light">/</span> ALGO
             </Link>
-            <p className="mt-4 text-sm leading-relaxed max-w-md">
-              Court-form-driven divorce document preparation tools, asset division calculators, and co-parenting solutions — built by an attorney licensed in 8 states.
+            <p className="mt-4 max-w-md text-sm leading-relaxed">
+              Court-form-driven document preparation tools, calculators, and family-law workflows designed to help people get organized before they spend more on legal help.
             </p>
             {/* Social placeholders */}
             <div className="flex gap-4 mt-6">


### PR DESCRIPTION
Closes #49

## Summary
- rewrite homepage marketing copy and move the product platform section directly under the hero
- remove developer-facing contact page notes and hide the bare public email display
- clean up pricing and product CTAs so public marketing pages stay self-serve and consistent
- remove attorney licensing language from shared metadata/footer marketing chrome

## Verification
- npm run lint
- ./node_modules/.bin/next build