### PR TITLE
fix: use shared Lexy shell on calculator pages

### DIFF
--- a/src/app/calculator/child-support/[state]/page.tsx
+++ b/src/app/calculator/child-support/[state]/page.tsx
@@ -4,7 +4,6 @@ import { notFound } from 'next/navigation';
 import { getStateBySlug, getAllStates } from '@/lib/state-formulas';
 import { CalculatorForm } from '@/components/calculator/CalculatorForm';
 import { Disclaimer } from '@/components/calculator/Disclaimer';
-import { CalculatorFooter } from '@/components/calculator/Footer';
 
 interface PageProps {
   params: Promise<{ state: string }>;
@@ -93,7 +92,6 @@ export default async function StateCalculatorPage({ params }: PageProps) {
         </Link>
       </div>
 
-      <CalculatorFooter />
     </div>
   );
 }

--- a/src/app/calculator/child-support/page.tsx
+++ b/src/app/calculator/child-support/page.tsx
@@ -3,7 +3,6 @@ import Link from 'next/link';
 import { getAllStates, getStatesByModel, getModelTypeLabel, getModelTypeDescription } from '@/lib/state-formulas';
 import { StateCard } from '@/components/calculator/StateCard';
 import { Disclaimer } from '@/components/calculator/Disclaimer';
-import { CalculatorFooter } from '@/components/calculator/Footer';
 
 export const metadata: Metadata = {
   title: 'Child Support Calculator — All 50 States + DC | LexyAlgo',
@@ -77,7 +76,6 @@ export default function ChildSupportHubPage() {
         <Disclaimer position="bottom" />
       </div>
 
-      <CalculatorFooter />
     </div>
   );
 }

--- a/src/app/calculator/page.tsx
+++ b/src/app/calculator/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import { CalculatorFooter } from '@/components/calculator';
 
 export const metadata: Metadata = {
   title: 'Free Legal Calculators | LexyAlgo',
@@ -99,7 +98,6 @@ export default function CalculatorHubPage() {
         </p>
       </div>
 
-      <CalculatorFooter />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- remove the calculator-only footer override from the calculator hub and child-support entry pages
- let those public calculator pages inherit the canonical site navbar/footer from the root app shell
- tighten the first live slice of #58 around the most obvious public shell drift inside `lexyalgo-site`

## Testing
- `npm run lint`

Closes #58