### PR TITLE
Route public product CTAs through shared auth

### DIFF
--- a/src/app/products/divorce/page.tsx
+++ b/src/app/products/divorce/page.tsx
@@ -1,13 +1,14 @@
 import Link from 'next/link'
 import type { Metadata } from 'next'
 import { RealScreenshot } from '@/components/RealScreenshot'
+import { sharedAuthLinks } from '@/lib/shared-auth-links'
 
 export const metadata: Metadata = {
   title: 'Divorce Forms — Free Public Alpha — LexyAlgo',
   description: 'Free public alpha for court-form-driven uncontested divorce workflows. One guided intake, state-specific forms, and clear early-alpha expectations.',
 }
 
-const PUBLIC_ALPHA_URL = 'https://app.lexyalgo.com'
+const PUBLIC_ALPHA_URL = sharedAuthLinks.divorceAlpha
 
 const features = [
   { title: 'Court-Form-Mapped Documents', desc: 'Not generic templates — every document maps directly to your state’s official court forms.' },

--- a/src/app/products/estate-planning/page.tsx
+++ b/src/app/products/estate-planning/page.tsx
@@ -1,12 +1,13 @@
 import Link from 'next/link'
 import type { Metadata } from 'next'
+import { sharedAuthLinks } from '@/lib/shared-auth-links'
 
 export const metadata: Metadata = {
   title: 'Estate Planning — Free — LexyAlgo',
   description: 'Free wills, trusts, powers of attorney, and healthcare directives. One intake, four core documents, and a clearer way to get your estate plan started.',
 }
 
-const DA_INTERVIEW_URL = 'https://doc.lexyalgo.com/interview?i=docassemble.EstatePlanning:data/questions/estate_planning.yml'
+const DA_INTERVIEW_URL = sharedAuthLinks.estatePlanning
 
 const features = [
   { title: 'Last Will and Testament', desc: 'A guided questionnaire produces a state-aware will covering distribution, guardianship, and executor appointment.' },

--- a/src/app/products/qdro/page.tsx
+++ b/src/app/products/qdro/page.tsx
@@ -1,10 +1,13 @@
 import Link from 'next/link'
 import type { Metadata } from 'next'
+import { sharedAuthLinks } from '@/lib/shared-auth-links'
 
 export const metadata: Metadata = {
   title: 'QDRO Generator — LexyAlgo',
   description: 'Generate a Qualified Domestic Relations Order (QDRO) for retirement plan division in divorce. Starting at $100 per order. Supports nearly one million plans nationwide.',
 }
+
+const QDRO_URL = sharedAuthLinks.qdro
 
 export default function QdroPage() {
   return (
@@ -28,7 +31,7 @@ export default function QdroPage() {
               A Qualified Domestic Relations Order divides retirement accounts in divorce. Our generator supports nearly one million plans across the country. Answer a few questions, and we generate the order for your plan.
             </p>
             <div className="mt-8 flex flex-col sm:flex-row gap-4">
-              <a href="https://doc.lexyalgo.com"
+              <a href={QDRO_URL}
                 className="inline-flex items-center justify-center bg-bronze text-white font-semibold px-8 py-4 rounded-2xl hover:bg-[#6F4A2E] transition-all shadow-lg shadow-bronze/20 hover:shadow-xl hover:shadow-bronze/30 active:scale-[0.98]"
               >
                 Generate a QDRO
@@ -50,7 +53,7 @@ export default function QdroPage() {
             <p className="text-sm font-semibold text-[#8B5E3C] uppercase tracking-wider mb-2">Available now</p>
             <p className="text-slate-700 leading-relaxed">
               The QDRO generator is live at{' '}
-              <a href="https://doc.lexyalgo.com" className="font-semibold text-[#8B5E3C] underline underline-offset-2 hover:text-[#6F4A2E]">
+              <a href={QDRO_URL} className="font-semibold text-[#8B5E3C] underline underline-offset-2 hover:text-[#6F4A2E]">
                 doc.lexyalgo.com
               </a>
               . Start your order there.
@@ -84,7 +87,7 @@ export default function QdroPage() {
               ))}
             </ul>
             <div className="mt-8">
-              <a href="https://doc.lexyalgo.com"
+              <a href={QDRO_URL}
                 className="block text-center font-semibold py-3 px-6 rounded-xl bg-bronze text-white hover:bg-[#6F4A2E] transition-all active:scale-[0.98]"
               >
                 Get Started
@@ -150,7 +153,7 @@ export default function QdroPage() {
           <h2 className="font-[family-name:var(--font-space)] text-3xl font-bold text-slate-900">Ready to divide the retirement plan?</h2>
           <p className="mt-4 text-slate-700 max-w-lg mx-auto">$100 per order. Answer the questions, get your QDRO.</p>
           <div className="mt-8 flex flex-col sm:flex-row gap-4 justify-center">
-            <a href="https://doc.lexyalgo.com"
+            <a href={QDRO_URL}
               className="inline-flex items-center justify-center bg-bronze text-white font-semibold px-8 py-4 rounded-2xl hover:bg-[#6F4A2E] transition-all shadow-lg shadow-bronze/20 active:scale-[0.98]"
             >
               Generate a QDRO

--- a/src/lib/shared-auth-links.ts
+++ b/src/lib/shared-auth-links.ts
@@ -1,0 +1,20 @@
+const ATLAS_LOGIN_URL = 'https://atlas.lexyalgo.com/login'
+const DOCASSEMBLE_ORIGIN = 'https://doc.lexyalgo.com'
+
+export const docassembleInterviews = {
+  divorce: `${DOCASSEMBLE_ORIGIN}/interview?i=docassemble.LexyAlgo:data/questions/ct_divorce.yml`,
+  estatePlanning: `${DOCASSEMBLE_ORIGIN}/interview?i=docassemble.LexyAlgo:data/questions/estate_planning.yml`,
+  qdro: `${DOCASSEMBLE_ORIGIN}/interview?i=docassemble.LexyAlgo:data/questions/qdro_router.yml`,
+} as const
+
+export function atlasLoginUrl(callbackUrl: string): string {
+  const url = new URL(ATLAS_LOGIN_URL)
+  url.searchParams.set('callbackUrl', callbackUrl)
+  return url.toString()
+}
+
+export const sharedAuthLinks = {
+  divorceAlpha: atlasLoginUrl('https://app.lexyalgo.com'),
+  estatePlanning: atlasLoginUrl(docassembleInterviews.estatePlanning),
+  qdro: atlasLoginUrl(docassembleInterviews.qdro),
+} as const


### PR DESCRIPTION
## Summary
- Add one shared-auth link helper for public-site product CTAs.
- Route Divorce Alpha, Estate Planning beta, and QDRO links through `https://atlas.lexyalgo.com/login?callbackUrl=...` instead of sending users directly to downstream surfaces.
- Point Estate Planning and QDRO callbacks at exact Docassemble interviews so the public site participates in the same Atlas-first session contract as the app repos.

## Proof
- `npm run lint` — passed
- `npm run build` — passed; 72 static pages generated

## Context
This complements the universal Supabase auth queue (`peacockesq/atlas-shell#27`) by making the marketing/public site entrypoints respect the one-login flow. Users coming from lexyalgo.com should establish/refresh the Atlas Supabase session first, then return to the exact downstream product callback.
