### PR TITLE
fix: hide unverified footer phone

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -51,9 +51,6 @@ export function Footer() {
               <p>
                 <Link href="/contact" className="transition-colors hover:text-slate-200">Use the contact form</Link>
               </p>
-              <p>
-                <a href="tel:+19294373767" className="transition-colors hover:text-slate-200">(929) 437-3767</a>
-              </p>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- removes the unverified footer phone link from the public LexyAlgo site
- keeps `/contact` as the supported public contact path until the support-number decision is verified

## Proof
- `npm run lint`
- `npm run build` (Tina + Next static build, 72 pages)

Fixes part of #6; #42 still tracks mailbox/FormSubmit activation proof.
