### PR TITLE
Harden contact form source proof

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -102,7 +102,7 @@ Set `DEPLOY_PATH` to the directory the web server already serves for that hostna
 
 ## Contact form activation
 
-The `/contact` page now posts to `https://formsubmit.co/hello@lexyalgo.com` so the static site has a real delivery path without adding server infrastructure.
+The `/contact` page now posts to `https://formsubmit.co/hello@lexyalgo.com` so the static site has a real delivery path without adding server infrastructure. The form includes the FormSubmit honeypot (`_honey`) plus an explicit `_url=https://lexyalgo.com/contact` source marker so mailbox reviewers can tie activation/delivery mail back to the live page.
 
 After the first live submission, FormSubmit will send an activation email to `hello@lexyalgo.com`. Someone with inbox access must click that activation link once before future submissions will deliver normally.
 

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -4,6 +4,7 @@ const contactInfo = [
 ]
 
 const formAction = 'https://formsubmit.co/hello@lexyalgo.com'
+const contactPageUrl = 'https://lexyalgo.com/contact'
 const thankYouUrl = 'https://lexyalgo.com/contact/thanks'
 
 export default function ContactPage() {
@@ -47,12 +48,13 @@ export default function ContactPage() {
               <div className="rounded-2xl border border-teal/20 bg-teal/5 p-5">
                 <p className="text-sm font-semibold text-slate-900">Send us a message</p>
                 <p className="mt-2 text-sm text-slate-700">
-                  Use the form below for product questions, feedback, partnerships, or press inquiries.
+                  Use the form below for product questions, feedback, partnerships, or press inquiries. Please do not include confidential case details here.
                 </p>
               </div>
 
               <input type="hidden" name="_subject" value="New LexyAlgo contact form submission" />
               <input type="hidden" name="_next" value={thankYouUrl} />
+              <input type="hidden" name="_url" value={contactPageUrl} />
               <input type="hidden" name="_template" value="table" />
               <input type="text" name="_honey" className="hidden" tabIndex={-1} autoComplete="off" />
 


### PR DESCRIPTION
## Summary
- add an explicit FormSubmit `_url` marker for the live `/contact` page
- add a no-confidential-case-details notice above the static contact form
- document the honeypot + source-marker proof path for mailbox activation review

## Related
- Supports #24
- Supports #42
- Supports #6

## Verification
- npm run lint
- npm run build