### PR TITLE
feat: add attribution persistence snippet

### DIFF
--- a/docs/attribution-persistence.md
+++ b/docs/attribution-persistence.md
@@ -16,24 +16,62 @@ Kanban: t_0208da0a
 
 ## Install
 
-Add the snippet once per landing page, preferably before the closing body tag:
+Add the snippet once per landing page, preferably before the closing body tag. The snippet is consent-safe by default: loading it does not write attribution data to `localStorage` until you explicitly initialize it.
 
 ```html
 <script src="/attribution-persistence.js" defer></script>
 ```
 
-Optional config before loading:
+Recommended consent-gated config before loading:
 
 ```html
 <script>
   window.AttributionPersistenceConfig = {
     storageKey: 'agency_attribution_v1',
     maxAgeDays: 90,
-    autoInit: true
+    autoInit: false,
+    consentMode: 'required',
+    hasConsent: function () {
+      return window.Cookiebot && window.Cookiebot.consent && window.Cookiebot.consent.marketing === true;
+    }
   };
 </script>
 <script src="/attribution-persistence.js" defer></script>
 ```
+
+## Consent banner / CMP integration
+
+Use your CMP's marketing-storage approval event to initialize capture after consent. Before `hasConsent` returns `true`, `capture()`, `hydrateForms()`, submit hydration, and `init()` are no-ops and `agency_attribution_v1` is not written.
+
+Cookiebot-style example:
+
+```html
+<script>
+  window.AttributionPersistenceConfig = {
+    autoInit: false,
+    consentMode: 'required',
+    hasConsent: function () {
+      return window.Cookiebot && window.Cookiebot.consent && window.Cookiebot.consent.marketing === true;
+    }
+  };
+
+  window.addEventListener('CookiebotOnAccept', function () {
+    if (window.AttributionPersistence) window.AttributionPersistence.init();
+  });
+</script>
+<script src="/attribution-persistence.js" defer></script>
+```
+
+Generic CMP example:
+
+```js
+cmp.on('consentChanged', function (consent) {
+  if (!consent.marketingStorage || !window.AttributionPersistence) return;
+  window.AttributionPersistence.setConsent(true);
+});
+```
+
+Sites that load the script only after consent can skip `hasConsent` and call `window.AttributionPersistence.init()` immediately after appending the script.
 
 ## Hidden fields supported
 
@@ -78,6 +116,8 @@ Minimum form field set recommended for CRM/n8n:
 window.AttributionPersistence.capture();
 window.AttributionPersistence.hydrateForms();
 window.AttributionPersistence.getPayload();
+window.AttributionPersistence.init();
+window.AttributionPersistence.setConsent(true);
 ```
 
 Use `hydrateForms(stepContainer)` after a custom multi-step form renders a new step if the site blocks MutationObserver or uses a shadow DOM form provider.
@@ -105,10 +145,11 @@ Browser QA fixture:
 
 Browser QA should verify:
 
-1. Load a page with synthetic UTMs and click IDs.
-2. Confirm hidden form fields are populated with first/latest touch values.
-3. Navigate or reload with a different source and confirm first-touch remains stable while latest-touch updates.
-4. Insert a later-step form dynamically and confirm hidden fields hydrate before submit.
+1. Load the snippet before consent with synthetic UTMs and click IDs; confirm `agency_attribution_v1` is absent from localStorage and hidden fields remain empty.
+2. Grant marketing-storage consent and call `window.AttributionPersistence.init()`.
+3. Confirm hidden form fields are populated with first/latest touch values.
+4. Navigate or reload with a different source and confirm first-touch remains stable while latest-touch updates.
+5. Insert a later-step form dynamically and confirm hidden fields hydrate before submit.
 
 Observed browser QA proof for this implementation:
 

--- a/docs/attribution-persistence.md
+++ b/docs/attribution-persistence.md
@@ -1,0 +1,117 @@
+# Attribution persistence snippet
+
+Issue: #71
+Kanban: t_0208da0a
+
+## What it does
+
+`public/attribution-persistence.js` is a reusable first-party browser snippet for marketing landing pages and embedded forms. It:
+
+- Captures UTM fields: `utm_source`, `utm_medium`, `utm_campaign`, `utm_term`, `utm_content`.
+- Captures paid click IDs: `gclid`, `gbraid`, `wbraid`, `fbclid`, `li_fat_id`, `msclkid`.
+- Captures source metadata: `landing_page_url`, `landing_page_path`, `referrer`, `captured_at`.
+- Persists `first_touch` and `latest_touch` separately in first-party `localStorage`.
+- Hydrates hidden inputs on all forms on page load, DOM insertion, and submit.
+- Supports multi-step forms where later steps are injected after the first page load.
+
+## Install
+
+Add the snippet once per landing page, preferably before the closing body tag:
+
+```html
+<script src="/attribution-persistence.js" defer></script>
+```
+
+Optional config before loading:
+
+```html
+<script>
+  window.AttributionPersistenceConfig = {
+    storageKey: 'agency_attribution_v1',
+    maxAgeDays: 90,
+    autoInit: true
+  };
+</script>
+<script src="/attribution-persistence.js" defer></script>
+```
+
+## Hidden fields supported
+
+For each attribution field, the snippet hydrates these naming patterns:
+
+- Latest/default: `utm_source`, `gclid`, `landing_page_url`, etc.
+- First-touch: `first_utm_source`, `first_touch_utm_source`, `attribution_first_utm_source`, etc.
+- Latest-touch: `latest_utm_source`, `latest_touch_utm_source`, `attribution_latest_utm_source`, etc.
+- Full JSON payload: `attribution_payload` or `attribution_json`.
+
+Minimum form field set recommended for CRM/n8n:
+
+```html
+<input type="hidden" name="first_utm_source">
+<input type="hidden" name="first_utm_medium">
+<input type="hidden" name="first_utm_campaign">
+<input type="hidden" name="first_gclid">
+<input type="hidden" name="first_gbraid">
+<input type="hidden" name="first_wbraid">
+<input type="hidden" name="first_fbclid">
+<input type="hidden" name="first_li_fat_id">
+<input type="hidden" name="first_msclkid">
+<input type="hidden" name="first_landing_page_url">
+<input type="hidden" name="first_referrer">
+<input type="hidden" name="latest_utm_source">
+<input type="hidden" name="latest_utm_medium">
+<input type="hidden" name="latest_utm_campaign">
+<input type="hidden" name="latest_gclid">
+<input type="hidden" name="latest_gbraid">
+<input type="hidden" name="latest_wbraid">
+<input type="hidden" name="latest_fbclid">
+<input type="hidden" name="latest_li_fat_id">
+<input type="hidden" name="latest_msclkid">
+<input type="hidden" name="latest_landing_page_url">
+<input type="hidden" name="latest_referrer">
+<input type="hidden" name="attribution_payload">
+```
+
+## Manual API
+
+```js
+window.AttributionPersistence.capture();
+window.AttributionPersistence.hydrateForms();
+window.AttributionPersistence.getPayload();
+```
+
+Use `hydrateForms(stepContainer)` after a custom multi-step form renders a new step if the site blocks MutationObserver or uses a shadow DOM form provider.
+
+## Verification
+
+Automated test:
+
+```bash
+npm run test:attribution
+```
+
+Build/lint checks:
+
+```bash
+npm run lint
+npm run build
+```
+
+Browser QA fixture:
+
+```text
+/attribution-qa.html?utm_source=google&utm_medium=cpc&utm_campaign=qa&utm_term=qdro&utm_content=test&gclid=GQA&gbraid=GBQA&wbraid=WBQA&fbclid=FBQA&li_fat_id=LIQA&msclkid=MSQA
+```
+
+Browser QA should verify:
+
+1. Load a page with synthetic UTMs and click IDs.
+2. Confirm hidden form fields are populated with first/latest touch values.
+3. Navigate or reload with a different source and confirm first-touch remains stable while latest-touch updates.
+4. Insert a later-step form dynamically and confirm hidden fields hydrate before submit.
+
+Observed browser QA proof for this implementation:
+
+- First load hydrated hidden fields with `first_utm_source=google`, `first_gclid=GQA`, `latest_utm_campaign=qa`, `latest_fbclid=FBQA`, and dynamic `latest_msclkid=MSQA`.
+- Second load on the same origin with `utm_source=linkedin&utm_campaign=second&li_fat_id=LISECOND&msclkid=MSSECOND` preserved `first_touch.utm_source=google` and `first_touch.gclid=GQA` while updating `latest_touch.utm_source=linkedin` and `latest_touch.msclkid=MSSECOND`.
+- The dynamically inserted step form hydrated `latest_msclkid=MSSECOND` before submit.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "tinacms build --local --skip-cloud-checks && next build",
     "start": "next start",
     "lint": "tsc --noEmit -p tsconfig.lint.json",
+    "test:attribution": "node tests/attribution-persistence.test.mjs",
     "verify:shared-auth-links": "node scripts/verify-shared-auth-links.mjs"
   },
   "keywords": [],

--- a/public/attribution-persistence.js
+++ b/public/attribution-persistence.js
@@ -9,8 +9,13 @@
  *   window.AttributionPersistenceConfig = {
  *     storageKey: 'agency_attribution_v1',
  *     maxAgeDays: 90,
- *     autoInit: true
+ *     autoInit: false,
+ *     consentMode: 'required',
+ *     hasConsent: function () { return window.Cookiebot && window.Cookiebot.consent.marketing; }
  *   };
+ *
+ * Load the script before consent if needed, then call AttributionPersistence.init()
+ * after your consent banner/CMP grants marketing-storage consent.
  */
 (function attributionPersistenceFactory(window) {
   'use strict';
@@ -86,6 +91,36 @@
     return store;
   }
 
+  function canCapture() {
+    if (typeof config.shouldCapture === 'function') {
+      try {
+        return config.shouldCapture({ config: config }) !== false;
+      } catch (error) {
+        return false;
+      }
+    }
+
+    if (typeof config.hasConsent === 'function') {
+      try {
+        return config.hasConsent({ config: config }) === true;
+      } catch (error) {
+        return false;
+      }
+    }
+
+    if (typeof config.hasConsent === 'boolean') return config.hasConsent;
+
+    if (config.consentMode === 'denied' || config.consentMode === false) return false;
+    if (config.consentMode === 'granted' || config.consentMode === true) return true;
+    if (config.consentMode === 'required') return false;
+
+    return true;
+  }
+
+  function emptyPayload() {
+    return { version: 1, first_touch: {}, latest_touch: {}, updated_at: '' };
+  }
+
   function paramsFromLocation() {
     var params = new URLSearchParams(window.location.search || '');
     var touch = {};
@@ -131,6 +166,8 @@
   }
 
   function capture() {
+    if (!canCapture()) return emptyPayload();
+
     var currentTouch = compactTouch(paramsFromLocation());
     var existing = readStore();
     var priorFirst = existing.first_touch && typeof existing.first_touch === 'object'
@@ -148,6 +185,8 @@
   }
 
   function getPayload() {
+    if (!canCapture()) return emptyPayload();
+
     var store = readStore();
     if (!store.first_touch || !store.latest_touch) store = capture();
     return store;
@@ -195,7 +234,7 @@
   }
 
   function hydrateForm(form, payload) {
-    if (!form || !form.querySelectorAll) return;
+    if (!form || !form.querySelectorAll || !canCapture()) return;
     var data = payload || getPayload();
     var inputs = form.querySelectorAll('input[type="hidden"][name]');
     for (var i = 0; i < inputs.length; i += 1) {
@@ -206,6 +245,8 @@
   }
 
   function hydrateForms(root) {
+    if (!canCapture()) return emptyPayload();
+
     var payload = getPayload();
     var scope = root && root.querySelectorAll ? root : document;
     if (scope.matches && scope.matches('form')) hydrateForm(scope, payload);
@@ -215,6 +256,8 @@
   }
 
   function attachSubmitHydration(root) {
+    if (!canCapture()) return;
+
     var scope = root && root.querySelectorAll ? root : document;
     var forms = [];
     if (scope.matches && scope.matches('form')) forms.push(scope);
@@ -250,11 +293,19 @@
   }
 
   function init() {
+    if (!canCapture()) return { payload: emptyPayload(), observer: null, consent: false };
+
     capture();
     hydrateForms();
     attachSubmitHydration();
     var observer = observeDynamicForms();
     return { payload: getPayload(), observer: observer };
+  }
+
+  function setConsent(granted) {
+    config.hasConsent = granted === true;
+    if (config.hasConsent) return init();
+    return { payload: emptyPayload(), observer: null, consent: false };
   }
 
   window.AttributionPersistence = {
@@ -263,10 +314,12 @@
     hydrateForm: hydrateForm,
     hydrateForms: hydrateForms,
     init: init,
+    setConsent: setConsent,
+    canCapture: canCapture,
     fields: ATTRIBUTION_FIELDS.slice()
   };
 
-  if (config.autoInit !== false) {
+  if (config.autoInit === true) {
     if (document.readyState === 'loading') {
       document.addEventListener('DOMContentLoaded', init, { once: true });
     } else {

--- a/public/attribution-persistence.js
+++ b/public/attribution-persistence.js
@@ -1,0 +1,276 @@
+/*
+ * Attribution Persistence
+ * Reusable first-party browser snippet for marketing forms.
+ *
+ * Usage:
+ *   <script src="/attribution-persistence.js" defer></script>
+ *
+ * Optional config before loading:
+ *   window.AttributionPersistenceConfig = {
+ *     storageKey: 'agency_attribution_v1',
+ *     maxAgeDays: 90,
+ *     autoInit: true
+ *   };
+ */
+(function attributionPersistenceFactory(window) {
+  'use strict';
+
+  if (!window || !window.document) return;
+
+  var document = window.document;
+  var config = window.AttributionPersistenceConfig || {};
+  var STORAGE_KEY = config.storageKey || 'agency_attribution_v1';
+  var MAX_AGE_DAYS = Number(config.maxAgeDays || 90);
+  var MAX_AGE_MS = MAX_AGE_DAYS * 24 * 60 * 60 * 1000;
+
+  var ATTRIBUTION_FIELDS = [
+    'utm_source',
+    'utm_medium',
+    'utm_campaign',
+    'utm_term',
+    'utm_content',
+    'gclid',
+    'gbraid',
+    'wbraid',
+    'fbclid',
+    'li_fat_id',
+    'msclkid',
+    'landing_page_url',
+    'landing_page_path',
+    'referrer',
+    'captured_at'
+  ];
+
+  function nowIso() {
+    return new Date().toISOString();
+  }
+
+  function safeStorage() {
+    try {
+      var storage = window.localStorage;
+      var probeKey = STORAGE_KEY + '_probe';
+      storage.setItem(probeKey, '1');
+      storage.removeItem(probeKey);
+      return storage;
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function readStore() {
+    var storage = safeStorage();
+    if (!storage) return {};
+    try {
+      var raw = storage.getItem(STORAGE_KEY);
+      if (!raw) return {};
+      var parsed = JSON.parse(raw);
+      if (parsed && parsed.updated_at) {
+        var age = Date.now() - Date.parse(parsed.updated_at);
+        if (Number.isFinite(age) && age > MAX_AGE_MS) return {};
+      }
+      return parsed && typeof parsed === 'object' ? parsed : {};
+    } catch (error) {
+      return {};
+    }
+  }
+
+  function writeStore(store) {
+    var storage = safeStorage();
+    if (!storage) return store;
+    try {
+      storage.setItem(STORAGE_KEY, JSON.stringify(store));
+    } catch (error) {
+      // Storage can fail in private mode or when quota is full. Hydration still works
+      // from the in-memory object returned to the caller.
+    }
+    return store;
+  }
+
+  function paramsFromLocation() {
+    var params = new URLSearchParams(window.location.search || '');
+    var touch = {};
+    for (var i = 0; i < ATTRIBUTION_FIELDS.length; i += 1) {
+      var field = ATTRIBUTION_FIELDS[i];
+      if (params.has(field)) touch[field] = params.get(field) || '';
+    }
+
+    touch.landing_page_url = String(window.location.href || '');
+    touch.landing_page_path = String(window.location.pathname || '');
+    touch.referrer = document.referrer || '';
+    touch.captured_at = nowIso();
+    return touch;
+  }
+
+  function hasAttributionSignal(touch) {
+    var signalFields = [
+      'utm_source',
+      'utm_medium',
+      'utm_campaign',
+      'utm_term',
+      'utm_content',
+      'gclid',
+      'gbraid',
+      'wbraid',
+      'fbclid',
+      'li_fat_id',
+      'msclkid'
+    ];
+    for (var i = 0; i < signalFields.length; i += 1) {
+      if (touch[signalFields[i]]) return true;
+    }
+    return Boolean(touch.referrer || touch.landing_page_url);
+  }
+
+  function compactTouch(touch) {
+    var out = {};
+    for (var i = 0; i < ATTRIBUTION_FIELDS.length; i += 1) {
+      var field = ATTRIBUTION_FIELDS[i];
+      if (touch[field] !== undefined && touch[field] !== null && touch[field] !== '') out[field] = touch[field];
+    }
+    return out;
+  }
+
+  function capture() {
+    var currentTouch = compactTouch(paramsFromLocation());
+    var existing = readStore();
+    var priorFirst = existing.first_touch && typeof existing.first_touch === 'object'
+      ? existing.first_touch
+      : null;
+    var shouldUpdateLatest = hasAttributionSignal(currentTouch);
+    var latest = shouldUpdateLatest ? currentTouch : (existing.latest_touch || currentTouch);
+    var store = {
+      version: 1,
+      first_touch: priorFirst || currentTouch,
+      latest_touch: latest,
+      updated_at: nowIso()
+    };
+    return writeStore(store);
+  }
+
+  function getPayload() {
+    var store = readStore();
+    if (!store.first_touch || !store.latest_touch) store = capture();
+    return store;
+  }
+
+  function candidatesForField(name) {
+    return [
+      name,
+      'first_' + name,
+      'first_touch_' + name,
+      'attribution_first_' + name,
+      'latest_' + name,
+      'latest_touch_' + name,
+      'attribution_latest_' + name
+    ];
+  }
+
+  function valueForInputName(inputName, payload) {
+    var name = String(inputName || '').trim();
+    if (!name) return null;
+
+    if (name === 'attribution_payload' || name === 'attribution_json') {
+      return JSON.stringify(payload);
+    }
+
+    for (var i = 0; i < ATTRIBUTION_FIELDS.length; i += 1) {
+      var field = ATTRIBUTION_FIELDS[i];
+      var candidates = candidatesForField(field);
+      if (candidates.indexOf(name) === -1) continue;
+
+      if (name.indexOf('first_') === 0 || name.indexOf('first_touch_') === 0 || name.indexOf('attribution_first_') === 0) {
+        return payload.first_touch && payload.first_touch[field] ? payload.first_touch[field] : '';
+      }
+
+      if (name.indexOf('latest_') === 0 || name.indexOf('latest_touch_') === 0 || name.indexOf('attribution_latest_') === 0) {
+        return payload.latest_touch && payload.latest_touch[field] ? payload.latest_touch[field] : '';
+      }
+
+      return payload.latest_touch && payload.latest_touch[field]
+        ? payload.latest_touch[field]
+        : (payload.first_touch && payload.first_touch[field] ? payload.first_touch[field] : '');
+    }
+
+    return null;
+  }
+
+  function hydrateForm(form, payload) {
+    if (!form || !form.querySelectorAll) return;
+    var data = payload || getPayload();
+    var inputs = form.querySelectorAll('input[type="hidden"][name]');
+    for (var i = 0; i < inputs.length; i += 1) {
+      var input = inputs[i];
+      var value = valueForInputName(input.name, data);
+      if (value !== null && value !== undefined) input.value = String(value);
+    }
+  }
+
+  function hydrateForms(root) {
+    var payload = getPayload();
+    var scope = root && root.querySelectorAll ? root : document;
+    if (scope.matches && scope.matches('form')) hydrateForm(scope, payload);
+    var forms = scope.querySelectorAll ? scope.querySelectorAll('form') : [];
+    for (var i = 0; i < forms.length; i += 1) hydrateForm(forms[i], payload);
+    return payload;
+  }
+
+  function attachSubmitHydration(root) {
+    var scope = root && root.querySelectorAll ? root : document;
+    var forms = [];
+    if (scope.matches && scope.matches('form')) forms.push(scope);
+    if (scope.querySelectorAll) {
+      var found = scope.querySelectorAll('form');
+      for (var i = 0; i < found.length; i += 1) forms.push(found[i]);
+    }
+    for (var j = 0; j < forms.length; j += 1) {
+      if (forms[j].__attributionPersistenceSubmitBound) continue;
+      forms[j].__attributionPersistenceSubmitBound = true;
+      forms[j].addEventListener('submit', function onSubmit() {
+        hydrateForm(this);
+      });
+    }
+  }
+
+  function observeDynamicForms() {
+    if (!window.MutationObserver || !document.documentElement) return null;
+    var observer = new window.MutationObserver(function onMutations(mutations) {
+      for (var i = 0; i < mutations.length; i += 1) {
+        var added = mutations[i].addedNodes || [];
+        for (var j = 0; j < added.length; j += 1) {
+          var node = added[j];
+          if (node && node.querySelectorAll) {
+            hydrateForms(node);
+            attachSubmitHydration(node);
+          }
+        }
+      }
+    });
+    observer.observe(document.documentElement, { childList: true, subtree: true });
+    return observer;
+  }
+
+  function init() {
+    capture();
+    hydrateForms();
+    attachSubmitHydration();
+    var observer = observeDynamicForms();
+    return { payload: getPayload(), observer: observer };
+  }
+
+  window.AttributionPersistence = {
+    capture: capture,
+    getPayload: getPayload,
+    hydrateForm: hydrateForm,
+    hydrateForms: hydrateForms,
+    init: init,
+    fields: ATTRIBUTION_FIELDS.slice()
+  };
+
+  if (config.autoInit !== false) {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', init, { once: true });
+    } else {
+      init();
+    }
+  }
+})(window);

--- a/public/attribution-qa.html
+++ b/public/attribution-qa.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Attribution persistence QA</title>
+  <script src="/attribution-persistence.js"></script>
+</head>
+<body>
+  <h1>Attribution persistence QA</h1>
+  <p>Load this page with synthetic UTMs/click IDs, then reload with a second source to verify first-touch/latest-touch persistence.</p>
+  <form id="lead-form">
+    <input type="hidden" name="first_utm_source">
+    <input type="hidden" name="first_gclid">
+    <input type="hidden" name="latest_utm_campaign">
+    <input type="hidden" name="latest_fbclid">
+    <input type="hidden" name="utm_source">
+    <input type="hidden" name="gclid">
+    <input type="hidden" name="referrer">
+    <input type="hidden" name="attribution_payload">
+    <button type="submit">Submit</button>
+  </form>
+  <div id="step-two"></div>
+  <pre id="proof"></pre>
+  <script>
+    function snapshot() {
+      window.AttributionPersistence.hydrateForms();
+      const values = Object.fromEntries(Array.from(document.querySelectorAll('input[type="hidden"][name]')).map((input) => [input.name, input.value]));
+      document.getElementById('proof').textContent = JSON.stringify(values, null, 2);
+      return values;
+    }
+    setTimeout(() => {
+      const step = document.createElement('form');
+      step.id = 'dynamic-step';
+      step.innerHTML = '<input type="hidden" name="latest_msclkid"><input type="hidden" name="attribution_payload"><button>Next</button>';
+      document.getElementById('step-two').appendChild(step);
+      step.dispatchEvent(new Event('submit'));
+      snapshot();
+    }, 50);
+    window.addEventListener('load', snapshot);
+  </script>
+</body>
+</html>

--- a/tests/attribution-persistence.test.mjs
+++ b/tests/attribution-persistence.test.mjs
@@ -72,6 +72,7 @@ function createStorage() {
     getItem(key) { return data.has(key) ? data.get(key) : null; },
     setItem(key, value) { data.set(key, String(value)); },
     removeItem(key) { data.delete(key); },
+    hasItem(key) { return data.has(key); },
   };
 }
 
@@ -165,6 +166,79 @@ function addForm(document, names) {
   const byName = Object.fromEntries(form.querySelectorAll('input[type="hidden"][name]').map((input) => [input.name, input.value]));
   assert.equal(byName.latest_msclkid, 'MS-123');
   assert.equal(JSON.parse(byName.attribution_payload).latest_touch.msclkid, 'MS-123');
+}
+
+{
+  const localStorage = createStorage();
+  loadAttribution({
+    localStorage,
+    url: 'https://example.com/default-load?utm_source=google&gclid=DEFAULT',
+  });
+  assert.equal(localStorage.hasItem('agency_attribution_v1'), false);
+}
+
+{
+  const localStorage = createStorage();
+  let hasConsent = false;
+  const { window, document } = loadAttribution({
+    localStorage,
+    AttributionPersistenceConfig: {
+      consentMode: 'required',
+      hasConsent: () => hasConsent,
+    },
+    url: 'https://example.com/pre-consent?utm_source=google&gclid=NOPE',
+  });
+  const form = addForm(document, ['first_utm_source', 'latest_gclid', 'attribution_payload']);
+
+  assert.equal(localStorage.hasItem('agency_attribution_v1'), false);
+  window.AttributionPersistence.init();
+  window.AttributionPersistence.hydrateForms();
+  form.dispatchEvent({ type: 'submit' });
+  const beforeConsent = Object.fromEntries(form.querySelectorAll('input[type="hidden"][name]').map((input) => [input.name, input.value]));
+  assert.equal(localStorage.hasItem('agency_attribution_v1'), false);
+  assert.equal(beforeConsent.first_utm_source, '');
+  assert.equal(beforeConsent.latest_gclid, '');
+  assert.equal(beforeConsent.attribution_payload, '');
+
+  hasConsent = true;
+  window.AttributionPersistence.init();
+  const afterConsent = Object.fromEntries(form.querySelectorAll('input[type="hidden"][name]').map((input) => [input.name, input.value]));
+  assert.equal(localStorage.hasItem('agency_attribution_v1'), true);
+  assert.equal(afterConsent.first_utm_source, 'google');
+  assert.equal(afterConsent.latest_gclid, 'NOPE');
+  assert.equal(JSON.parse(afterConsent.attribution_payload).first_touch.gclid, 'NOPE');
+}
+
+{
+  let granted = false;
+  const localStorage = createStorage();
+  loadAttribution({
+    localStorage,
+    AttributionPersistenceConfig: { consentMode: 'required', hasConsent: () => granted },
+    url: 'https://example.com/first?utm_source=google&gclid=FIRST',
+  });
+  assert.equal(localStorage.hasItem('agency_attribution_v1'), false);
+
+  granted = true;
+  loadAttribution({
+    localStorage,
+    AttributionPersistenceConfig: { consentMode: 'required', hasConsent: () => granted },
+    url: 'https://example.com/first?utm_source=google&gclid=FIRST',
+  }).window.AttributionPersistence.init();
+  const { window, document } = loadAttribution({
+    localStorage,
+    AttributionPersistenceConfig: { consentMode: 'required', hasConsent: () => granted },
+    url: 'https://example.com/second?utm_source=linkedin&li_fat_id=LATEST',
+  });
+  window.AttributionPersistence.capture();
+  const form = addForm(document, ['first_utm_source', 'first_gclid', 'latest_utm_source', 'latest_li_fat_id', 'landing_page_url']);
+  window.AttributionPersistence.hydrateForms();
+  const byName = Object.fromEntries(form.querySelectorAll('input[type="hidden"][name]').map((input) => [input.name, input.value]));
+  assert.equal(byName.first_utm_source, 'google');
+  assert.equal(byName.first_gclid, 'FIRST');
+  assert.equal(byName.latest_utm_source, 'linkedin');
+  assert.equal(byName.latest_li_fat_id, 'LATEST');
+  assert.equal(byName.landing_page_url, 'https://example.com/second?utm_source=linkedin&li_fat_id=LATEST');
 }
 
 console.log('attribution-persistence tests passed');

--- a/tests/attribution-persistence.test.mjs
+++ b/tests/attribution-persistence.test.mjs
@@ -1,0 +1,170 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import vm from 'node:vm';
+
+class FakeElement {
+  constructor(tagName, attrs = {}) {
+    this.tagName = tagName.toUpperCase();
+    this.children = [];
+    this.parentNode = null;
+    this.attributes = { ...attrs };
+    this.name = attrs.name || '';
+    this.type = attrs.type || '';
+    this.value = attrs.value || '';
+    this.listeners = {};
+  }
+
+  appendChild(child) {
+    child.parentNode = this;
+    this.children.push(child);
+    return child;
+  }
+
+  addEventListener(type, handler) {
+    this.listeners[type] ||= [];
+    this.listeners[type].push(handler);
+  }
+
+  dispatchEvent(event) {
+    for (const handler of this.listeners[event.type] || []) handler.call(this, event);
+  }
+
+  matches(selector) {
+    if (selector === 'form') return this.tagName === 'FORM';
+    if (selector === 'input[type="hidden"][name]') {
+      return this.tagName === 'INPUT' && this.type === 'hidden' && Boolean(this.name);
+    }
+    return false;
+  }
+
+  querySelectorAll(selector) {
+    const out = [];
+    const walk = (node) => {
+      for (const child of node.children) {
+        if (child.matches(selector)) out.push(child);
+        walk(child);
+      }
+    };
+    walk(this);
+    return out;
+  }
+}
+
+class FakeDocument extends FakeElement {
+  constructor() {
+    super('#document');
+    this.documentElement = new FakeElement('html');
+    this.body = new FakeElement('body');
+    this.appendChild(this.documentElement);
+    this.documentElement.appendChild(this.body);
+    this.referrer = 'https://referrer.example/source';
+    this.listeners = {};
+  }
+
+  createElement(tagName) {
+    return new FakeElement(tagName);
+  }
+}
+
+function createStorage() {
+  const data = new Map();
+  return {
+    getItem(key) { return data.has(key) ? data.get(key) : null; },
+    setItem(key, value) { data.set(key, String(value)); },
+    removeItem(key) { data.delete(key); },
+  };
+}
+
+function loadAttribution(windowOverrides = {}) {
+  const code = fs.readFileSync(new URL('../public/attribution-persistence.js', import.meta.url), 'utf8');
+  const document = windowOverrides.document || new FakeDocument();
+  const window = {
+    document,
+    location: new URL(windowOverrides.url || 'https://example.com/landing?utm_source=google&utm_medium=cpc&utm_campaign=diagnostic&utm_term=qdro&utm_content=ad-a&gclid=G-123&gbraid=GB-123&wbraid=WB-123&fbclid=FB-123&li_fat_id=LI-123&msclkid=MS-123'),
+    localStorage: windowOverrides.localStorage || createStorage(),
+    MutationObserver: class {
+      constructor(callback) { this.callback = callback; window.__observer = this; }
+      observe() {}
+      trigger() { this.callback([{ addedNodes: [document.body] }]); }
+    },
+    addEventListener(type, handler) { document.addEventListener(type, handler); },
+    removeEventListener() {},
+    console,
+    Date,
+    JSON,
+    URLSearchParams,
+    setTimeout,
+    clearTimeout,
+    ...windowOverrides,
+  };
+  window.window = window;
+  const context = vm.createContext(window);
+  vm.runInContext(code, context);
+  return { window, document };
+}
+
+function addForm(document, names) {
+  const form = new FakeElement('form');
+  for (const name of names) form.appendChild(new FakeElement('input', { type: 'hidden', name }));
+  document.body.appendChild(form);
+  return form;
+}
+
+{
+  const { window, document } = loadAttribution();
+  const form = addForm(document, [
+    'first_utm_source',
+    'first_gclid',
+    'first_landing_page_url',
+    'latest_utm_campaign',
+    'latest_fbclid',
+    'utm_source',
+    'gclid',
+    'referrer',
+    'attribution_payload',
+  ]);
+
+  window.AttributionPersistence.capture();
+  window.AttributionPersistence.hydrateForms();
+
+  const byName = Object.fromEntries(form.querySelectorAll('input[type="hidden"][name]').map((input) => [input.name, input.value]));
+  assert.equal(byName.first_utm_source, 'google');
+  assert.equal(byName.first_gclid, 'G-123');
+  assert.equal(byName.first_landing_page_url, 'https://example.com/landing?utm_source=google&utm_medium=cpc&utm_campaign=diagnostic&utm_term=qdro&utm_content=ad-a&gclid=G-123&gbraid=GB-123&wbraid=WB-123&fbclid=FB-123&li_fat_id=LI-123&msclkid=MS-123');
+  assert.equal(byName.latest_utm_campaign, 'diagnostic');
+  assert.equal(byName.latest_fbclid, 'FB-123');
+  assert.equal(byName.utm_source, 'google');
+  assert.equal(byName.gclid, 'G-123');
+  assert.equal(byName.referrer, 'https://referrer.example/source');
+  const payload = JSON.parse(byName.attribution_payload);
+  assert.equal(payload.first_touch.utm_source, 'google');
+  assert.equal(payload.latest_touch.gbraid, 'GB-123');
+}
+
+{
+  const localStorage = createStorage();
+  loadAttribution({ localStorage, url: 'https://example.com/first?utm_source=google&gclid=FIRST' }).window.AttributionPersistence.capture();
+  const { window, document } = loadAttribution({ localStorage, url: 'https://example.com/second?utm_source=linkedin&li_fat_id=LATEST' });
+  window.AttributionPersistence.capture();
+  const form = addForm(document, ['first_utm_source', 'first_gclid', 'latest_utm_source', 'latest_li_fat_id', 'landing_page_url']);
+  window.AttributionPersistence.hydrateForms();
+  const byName = Object.fromEntries(form.querySelectorAll('input[type="hidden"][name]').map((input) => [input.name, input.value]));
+  assert.equal(byName.first_utm_source, 'google');
+  assert.equal(byName.first_gclid, 'FIRST');
+  assert.equal(byName.latest_utm_source, 'linkedin');
+  assert.equal(byName.latest_li_fat_id, 'LATEST');
+  assert.equal(byName.landing_page_url, 'https://example.com/second?utm_source=linkedin&li_fat_id=LATEST');
+}
+
+{
+  const { window, document } = loadAttribution();
+  window.AttributionPersistence.init();
+  const form = addForm(document, ['latest_msclkid', 'attribution_payload']);
+  window.__observer.trigger();
+  form.dispatchEvent({ type: 'submit' });
+  const byName = Object.fromEntries(form.querySelectorAll('input[type="hidden"][name]').map((input) => [input.name, input.value]));
+  assert.equal(byName.latest_msclkid, 'MS-123');
+  assert.equal(JSON.parse(byName.attribution_payload).latest_touch.msclkid, 'MS-123');
+}
+
+console.log('attribution-persistence tests passed');

--- a/tests/fixtures/attribution-qa.html
+++ b/tests/fixtures/attribution-qa.html
@@ -3,6 +3,14 @@
 <head>
   <meta charset="utf-8">
   <title>Attribution persistence QA</title>
+  <script>
+    window.__attributionConsentGranted = false;
+    window.AttributionPersistenceConfig = {
+      autoInit: false,
+      consentMode: 'required',
+      hasConsent: function () { return window.__attributionConsentGranted === true; }
+    };
+  </script>
   <script src="/public/attribution-persistence.js"></script>
 </head>
 <body>
@@ -19,6 +27,7 @@
     <button type="submit">Submit</button>
   </form>
   <div id="step-two"></div>
+  <button id="grant-consent" type="button">Grant marketing consent</button>
   <pre id="proof"></pre>
   <script>
     function snapshot() {
@@ -35,6 +44,11 @@
       step.dispatchEvent(new Event('submit'));
       snapshot();
     }, 50);
+    document.getElementById('grant-consent').addEventListener('click', () => {
+      window.__attributionConsentGranted = true;
+      window.AttributionPersistence.init();
+      snapshot();
+    });
     window.addEventListener('load', snapshot);
   </script>
 </body>

--- a/tests/fixtures/attribution-qa.html
+++ b/tests/fixtures/attribution-qa.html
@@ -3,11 +3,10 @@
 <head>
   <meta charset="utf-8">
   <title>Attribution persistence QA</title>
-  <script src="/attribution-persistence.js"></script>
+  <script src="/public/attribution-persistence.js"></script>
 </head>
 <body>
   <h1>Attribution persistence QA</h1>
-  <p>Load this page with synthetic UTMs/click IDs, then reload with a second source to verify first-touch/latest-touch persistence.</p>
   <form id="lead-form">
     <input type="hidden" name="first_utm_source">
     <input type="hidden" name="first_gclid">


### PR DESCRIPTION
## Summary
- Adds reusable first-party attribution persistence browser snippet for UTMs, click IDs, referrer, landing page URL/path, and timestamps.
- Persists first-touch/latest-touch attribution in localStorage and hydrates hidden fields on initial, dynamically inserted, and submit-time forms.
- Adds Node tests, a non-public browser QA fixture, and documentation for hidden-field naming conventions.

## Test Plan
- npm run test:attribution
- npm run lint
- npx tinacms build --local --skip-cloud-checks --datalayer-port 9001 && npx next build
- Browser QA: served repo root locally, loaded tests/fixtures/attribution-qa.html with synthetic Google first touch and LinkedIn latest touch; verified first_utm_source/first_gclid stayed google/G-123, latest_utm_campaign updated to retarget, and dynamic step hydrated latest_msclkid=MS-LATEST.
- npm audit --omit=dev was run; it reports existing TinaCMS/Next transitive vulnerabilities unrelated to this snippet and no dependency changes were made in this PR.

Closes #71
