### PR TITLE
feat: add internal agency website shell

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -32,6 +32,27 @@
   --color-violet-light: #EDE9F8;
   --font-space: 'Space Grotesk', sans-serif;
   --font-inter: 'Inter', sans-serif;
+  --color-agency-primary: #4F46E5;
+  --color-agency-canvas: #F7F9FC;
+  --color-agency-surface: #FFFFFF;
+  --color-agency-surface-muted: #EEF3F8;
+  --color-agency-ink: #0B1020;
+  --color-agency-text: #182033;
+  --color-agency-text-muted: #596579;
+  --color-agency-border: #D8E1EC;
+  --color-agency-border-strong: #B8C7D9;
+  --color-agency-accent-hover: #3730A3;
+  --color-agency-accent-soft: #E9E7FF;
+  --color-agency-cyan: #0EA5E9;
+  --color-agency-cyan-soft: #E6F6FE;
+  --color-agency-proof-panel: #0A0F1F;
+  --color-agency-proof-panel-raised: #111B33;
+  --color-agency-proof-border: #253250;
+  --color-agency-proof-text: #F8FAFC;
+  --color-agency-proof-text-muted: #AEBBD0;
+  --color-agency-warning: #A15C07;
+  --color-agency-warning-soft: #FFF4DA;
+  --color-agency-danger: #B42318;
 }
 
 @layer base {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -68,3 +68,14 @@
     font-family: var(--font-space);
   }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .agency-artifact *,
+  .agency-artifact *::before,
+  .agency-artifact *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/src/app/internal/legal-growth-os/page.tsx
+++ b/src/app/internal/legal-growth-os/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next'
+import { AgencyHomeShell } from '@/components/AgencySiteShell'
+
+export const metadata: Metadata = {
+  title: 'Internal Legal Growth OS Website Shell — LexyAlgo',
+  description: 'Internal staging artifact for the Legal Growth Operating System agency website shell. Not approved for public publication.',
+  robots: {
+    index: false,
+    follow: false,
+  },
+}
+
+export default function InternalLegalGrowthOsPage() {
+  return <AgencyHomeShell />
+}

--- a/src/app/internal/legal-growth-os/templates/page.tsx
+++ b/src/app/internal/legal-growth-os/templates/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next'
+import { AgencyTemplatesShell } from '@/components/AgencySiteShell'
+
+export const metadata: Metadata = {
+  title: 'Internal Legal Growth OS Template Library — LexyAlgo',
+  description: 'Internal staging artifact for Legal Growth Operating System reusable page templates. Not approved for public publication.',
+  robots: {
+    index: false,
+    follow: false,
+  },
+}
+
+export default function InternalLegalGrowthOsTemplatesPage() {
+  return <AgencyTemplatesShell />
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,8 @@
 import type { Metadata } from 'next'
 import { Space_Grotesk, Inter } from 'next/font/google'
-import Script from 'next/script'
 import './globals.css'
 import { SiteChrome } from '@/components/SiteChrome'
-import GoogleAnalytics from '@/components/GoogleAnalytics'
+import { AnalyticsGate } from '@/components/AnalyticsGate'
 
 const spaceGrotesk = Space_Grotesk({
   subsets: ['latin'],
@@ -37,31 +36,8 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" className={`${spaceGrotesk.variable} ${inter.variable}`}>
-      <head>
-        {/* Google Tag Manager */}
-        <Script
-          id="gtm-script"
-          strategy="afterInteractive"
-          dangerouslySetInnerHTML={{
-            __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-TMZRCGT');`,
-          }}
-        />
-      </head>
       <body className="min-h-screen flex flex-col">
-        {/* Google Tag Manager (noscript) */}
-        <noscript>
-          <iframe
-            src="https://www.googletagmanager.com/ns.html?id=GTM-TMZRCGT"
-            height="0"
-            width="0"
-            style={{ display: 'none', visibility: 'hidden' }}
-          />
-        </noscript>
-        <GoogleAnalytics />
+        <AnalyticsGate />
         <SiteChrome>{children}</SiteChrome>
       </body>
     </html>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,8 +2,7 @@ import type { Metadata } from 'next'
 import { Space_Grotesk, Inter } from 'next/font/google'
 import Script from 'next/script'
 import './globals.css'
-import { Navbar } from '@/components/Navbar'
-import { Footer } from '@/components/Footer'
+import { SiteChrome } from '@/components/SiteChrome'
 import GoogleAnalytics from '@/components/GoogleAnalytics'
 
 const spaceGrotesk = Space_Grotesk({
@@ -63,9 +62,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           />
         </noscript>
         <GoogleAnalytics />
-        <Navbar />
-        <main className="flex-1">{children}</main>
-        <Footer />
+        <SiteChrome>{children}</SiteChrome>
       </body>
     </html>
   )

--- a/src/components/AgencySiteShell.tsx
+++ b/src/components/AgencySiteShell.tsx
@@ -1,0 +1,367 @@
+import Link from 'next/link'
+import { faqs, processSteps, proofStrip, services, templateCards } from '@/lib/agency-site-content'
+
+const focusRing = 'focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-4 focus-visible:outline-[#4F46E5]'
+
+function PrimaryLink({ href, children }: { href: string; children: React.ReactNode }) {
+  return (
+    <Link
+      href={href}
+      className={`inline-flex min-h-11 items-center justify-center rounded-lg bg-[#4F46E5] px-5 py-3 text-sm font-semibold text-white shadow-[0_16px_35px_rgba(79,70,229,.22)] transition hover:-translate-y-0.5 hover:bg-[#3730A3] ${focusRing}`}
+    >
+      {children}
+    </Link>
+  )
+}
+
+function SecondaryLink({ href, children, dark = false }: { href: string; children: React.ReactNode; dark?: boolean }) {
+  return (
+    <Link
+      href={href}
+      className={`inline-flex min-h-11 items-center justify-center rounded-lg border px-5 py-3 text-sm font-semibold transition hover:-translate-y-0.5 ${focusRing} ${
+        dark
+          ? 'border-[#253250] bg-white text-[#0A0F1F] hover:border-white'
+          : 'border-[#D8E1EC] bg-white text-[#0B1020] hover:border-[#B8C7D9]'
+      }`}
+    >
+      {children}
+    </Link>
+  )
+}
+
+function SectionHeader({ eyebrow, title, copy, light = false }: { eyebrow: string; title: string; copy?: string; light?: boolean }) {
+  return (
+    <div className="mx-auto mb-10 max-w-3xl text-center">
+      <p className={`text-xs font-bold uppercase tracking-[0.22em] ${light ? 'text-[#AEBBD0]' : 'text-[#4F46E5]'}`}>{eyebrow}</p>
+      <h2 className={`mt-3 text-3xl font-semibold leading-tight tracking-[-0.035em] sm:text-4xl ${light ? 'text-white' : 'text-[#0B1020]'}`}>{title}</h2>
+      {copy ? <p className={`mt-4 text-base leading-7 ${light ? 'text-[#AEBBD0]' : 'text-[#596579]'}`}>{copy}</p> : null}
+    </div>
+  )
+}
+
+function HeroLoopCard() {
+  const nodes = ['Query intent', 'Landing-page test', 'Qualified lead', 'Budget decision']
+
+  return (
+    <div className="relative rounded-[1.5rem] border border-[#D8E1EC] bg-white p-4 shadow-[0_24px_70px_rgba(25,42,70,.16)] sm:p-6">
+      <div className="flex items-center gap-2 border-b border-[#D8E1EC] pb-4">
+        <span className="h-3 w-3 rounded-full bg-[#F87171]" />
+        <span className="h-3 w-3 rounded-full bg-[#FBBF24]" />
+        <span className="h-3 w-3 rounded-full bg-[#34D399]" />
+        <span className="ml-3 rounded-md border border-[#D8E1EC] bg-[#F7F9FC] px-2 py-1 text-[11px] font-medium text-[#596579]">growth-os.internal/loop</span>
+      </div>
+      <div className="mt-5 rounded-2xl bg-gradient-to-br from-[#F7F9FC] via-white to-[#E6F6FE] p-5">
+        <div className="grid gap-3 sm:grid-cols-2">
+          {nodes.map((node, index) => (
+            <div key={node} className="rounded-xl border border-[#D8E1EC] bg-white/90 p-4 shadow-[0_1px_2px_rgba(11,16,32,.06)]">
+              <span className="text-[11px] font-bold uppercase tracking-[0.18em] text-[#4F46E5]">0{index + 1}</span>
+              <p className="mt-2 text-sm font-semibold text-[#0B1020]">{node}</p>
+            </div>
+          ))}
+        </div>
+        <div className="mt-5 rounded-2xl border border-[#253250] bg-[#0A0F1F] p-4 text-white">
+          <p className="text-xs font-bold uppercase tracking-[0.18em] text-[#AEBBD0]">Decision payload</p>
+          <p className="mt-2 text-sm leading-6 text-[#F8FAFC]">What changed, what evidence supports it, and what budget or operating decision follows.</p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function TrustStrip() {
+  return (
+    <section className="border-y border-[#D8E1EC] bg-white">
+      <div className="mx-auto grid max-w-[1180px] gap-4 px-4 py-8 sm:grid-cols-2 lg:grid-cols-4 lg:px-8">
+        {proofStrip.map((item) => (
+          <div key={item.label} className="rounded-2xl border border-[#D8E1EC] bg-[#F7F9FC] p-5">
+            <p className="font-mono text-sm font-bold text-[#0B1020]">{item.label}</p>
+            <p className="mt-2 text-sm leading-6 text-[#596579]">{item.detail}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function ProblemFraming() {
+  const leaks = ['Paid spend judged by platform conversions alone', 'SEO work separated from commercial demand', 'Landing pages disconnected from query intent', 'CRM feedback never reaches budget decisions', 'Automation hides failure instead of surfacing signal']
+
+  return (
+    <section id="operating-loop" className="bg-[#F7F9FC] px-4 py-20 sm:py-28 lg:px-8">
+      <div className="mx-auto grid max-w-[1180px] gap-8 lg:grid-cols-2">
+        <div className="rounded-[1.5rem] border border-[#D8E1EC] bg-white p-6 shadow-[0_16px_40px_rgba(25,42,70,.10)] sm:p-8">
+          <p className="text-xs font-bold uppercase tracking-[0.22em] text-[#A15C07]">Fragmented stack</p>
+          <h2 className="mt-3 text-3xl font-semibold tracking-[-0.035em] text-[#0B1020]">Most growth systems leak signal before they leak budget.</h2>
+          <div className="mt-6 space-y-3">
+            {leaks.map((leak) => (
+              <div key={leak} className="flex gap-3 rounded-xl border border-[#F8D8A7] bg-[#FFF4DA] p-4 text-sm leading-6 text-[#182033]">
+                <span aria-hidden="true" className="mt-0.5 font-bold text-[#A15C07]">!</span>
+                <span>{leak}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="rounded-[1.5rem] border border-[#253250] bg-[#0A0F1F] p-6 text-white shadow-[0_24px_80px_rgba(79,70,229,.22)] sm:p-8">
+          <p className="text-xs font-bold uppercase tracking-[0.22em] text-[#AEBBD0]">Operating system</p>
+          <h2 className="mt-3 text-3xl font-semibold tracking-[-0.035em] text-white">Connect every channel to one qualified-demand decision loop.</h2>
+          <p className="mt-4 text-base leading-7 text-[#AEBBD0]">The shell treats paid media, AI search, landing pages, tracking, and automation as one system. Proof stays caveated until verified; green/status styling is reserved for validated performance only.</p>
+          <div className="mt-8 grid gap-3 sm:grid-cols-2">
+            {['Source', 'Page', 'Lead', 'Decision'].map((label) => (
+              <div key={label} className="rounded-xl border border-[#253250] bg-[#111B33] p-4">
+                <p className="text-sm font-semibold text-white">{label}</p>
+                <p className="mt-2 text-xs leading-5 text-[#AEBBD0]">Context, caveat, and next action slot.</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function ServicesGrid() {
+  return (
+    <section id="services" className="bg-white px-4 py-20 sm:py-28 lg:px-8">
+      <div className="mx-auto max-w-[1180px]">
+        <SectionHeader eyebrow="Services" title="Six modules, one acquisition loop." copy="Each card describes the constraint, the system output, and the measurement family instead of a generic service blurb." />
+        <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-3">
+          {services.map((service) => (
+            <Link key={service.title} href={service.href} className={`group rounded-[1.125rem] border border-[#D8E1EC] bg-white p-6 shadow-[0_1px_2px_rgba(11,16,32,.06)] transition hover:-translate-y-1 hover:border-[#B8C7D9] hover:shadow-[0_16px_40px_rgba(25,42,70,.10)] ${focusRing}`}>
+              <p className="text-xs font-bold uppercase tracking-[0.18em] text-[#4F46E5]">{service.constraint}</p>
+              <h3 className="mt-4 text-xl font-semibold tracking-[-0.02em] text-[#0B1020]">{service.title}</h3>
+              <p className="mt-3 text-sm leading-6 text-[#596579]">{service.output}</p>
+              <div className="mt-5 flex flex-wrap gap-2">
+                {service.tags.map((tag) => (
+                  <span key={tag} className="rounded-full bg-[#EEF3F8] px-3 py-1 text-xs font-semibold text-[#182033]">{tag}</span>
+                ))}
+              </div>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function ProcessPanel() {
+  return (
+    <section id="proof" className="bg-[#F7F9FC] px-4 py-20 sm:py-28 lg:px-8">
+      <div className="mx-auto max-w-[1180px] rounded-[1.5rem] border border-[#253250] bg-[#0A0F1F] p-6 shadow-[0_24px_80px_rgba(79,70,229,.22)] sm:p-8 lg:p-10">
+        <SectionHeader light eyebrow="Signature workflow" title="Diagnose → Instrument → Build → Launch → Measure → Iterate." copy="The dark panel is reserved for technical process and evidence architecture, per the design handoff." />
+        <div className="grid gap-3 md:grid-cols-3 lg:grid-cols-6">
+          {processSteps.map((item) => (
+            <div key={item.step} className="rounded-2xl border border-[#253250] bg-[#111B33] p-4">
+              <p className="font-mono text-xs font-bold text-[#AEBBD0]">{item.step}</p>
+              <h3 className="mt-3 text-base font-semibold text-white">{item.title}</h3>
+              <p className="mt-2 text-xs leading-5 text-[#AEBBD0]">{item.copy}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function CaseStudyModule() {
+  return (
+    <section className="bg-white px-4 py-20 sm:py-28 lg:px-8">
+      <div className="mx-auto grid max-w-[1180px] gap-8 lg:grid-cols-[1fr_.9fr]">
+        <div className="rounded-[1.5rem] border border-[#D8E1EC] bg-white p-6 shadow-[0_16px_40px_rgba(25,42,70,.10)] sm:p-8">
+          <p className="text-xs font-bold uppercase tracking-[0.22em] text-[#4F46E5]">Proof-safe case module</p>
+          <h2 className="mt-3 text-3xl font-semibold tracking-[-0.035em] text-[#0B1020]">Evidence slots are designed before public claims exist.</h2>
+          <dl className="mt-6 grid gap-4 sm:grid-cols-2">
+            {['Starting constraint', 'Intervention', 'Measurement window', 'Result/caveat state'].map((field) => (
+              <div key={field} className="rounded-xl border border-[#D8E1EC] bg-[#F7F9FC] p-4">
+                <dt className="text-xs font-bold uppercase tracking-[0.16em] text-[#596579]">{field}</dt>
+                <dd className="mt-2 text-sm text-[#182033]">Placeholder field; requires verified source before publication.</dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+        <div className="rounded-[1.5rem] border border-[#253250] bg-[#0A0F1F] p-6 text-white sm:p-8">
+          <p className="text-xs font-bold uppercase tracking-[0.22em] text-[#AEBBD0]">Publication gate</p>
+          <p className="mt-3 text-2xl font-semibold tracking-[-0.025em]">No public numeric outcome, testimonial, screenshot, or client-identifying detail.</p>
+          <p className="mt-4 text-sm leading-6 text-[#AEBBD0]">Evidence source, redaction, claim-risk level, caveat language, and Willie/team approval are required before this component can carry public proof.</p>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function LoopLanes() {
+  const lanes = [
+    ['AI Search Visibility', 'Query set, answer presence, entity consistency, citations, and missing commercial assets.'],
+    ['Paid Media Signal', 'Intent tier, search terms, landing-page fit, event quality, and CRM qualified-lead feedback.'],
+    ['Landing-Page Conversion', 'Offer clarity, proof fit, friction points, test plan, and diagnostic next action.'],
+  ]
+
+  return (
+    <section className="bg-[#F7F9FC] px-4 py-20 sm:py-28 lg:px-8">
+      <div className="mx-auto max-w-[1180px]">
+        <SectionHeader eyebrow="Conversion loop" title="AI search, paid media, and landing pages move as one system." />
+        <div className="grid gap-5 lg:grid-cols-3">
+          {lanes.map(([title, copy]) => (
+            <div key={title} className="rounded-[1.125rem] border border-[#D8E1EC] bg-white p-6 shadow-[0_1px_2px_rgba(11,16,32,.06)]">
+              <h3 className="text-xl font-semibold tracking-[-0.02em] text-[#0B1020]">{title}</h3>
+              <p className="mt-3 text-sm leading-6 text-[#596579]">{copy}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function DiagnosticForm() {
+  return (
+    <section id="diagnostic" className="bg-white px-4 py-20 sm:py-28 lg:px-8">
+      <div className="mx-auto grid max-w-[1180px] gap-8 rounded-[1.5rem] border border-[#253250] bg-[#0A0F1F] p-6 text-white shadow-[0_24px_80px_rgba(79,70,229,.22)] sm:p-8 lg:grid-cols-[.9fr_1fr] lg:p-10">
+        <div>
+          <p className="text-xs font-bold uppercase tracking-[0.22em] text-[#AEBBD0]">Growth Diagnostic</p>
+          <h2 className="mt-3 text-3xl font-semibold tracking-[-0.035em]">Start with the constraint, not a retainer pitch.</h2>
+          <p className="mt-4 text-base leading-7 text-[#AEBBD0]">No generic audit deck. You get the likely constraint, the evidence behind it, and the next decision it supports.</p>
+          <div className="mt-6 rounded-xl border border-[#253250] bg-[#111B33] p-4 text-sm leading-6 text-[#AEBBD0]">
+            Stub only: this internal form uses a GET action back to this route. No live lead capture or outbound delivery is connected.
+          </div>
+        </div>
+        <form action="/internal/legal-growth-os#diagnostic-stub" method="get" className="rounded-2xl border border-[#253250] bg-white p-5 text-[#0B1020] sm:p-6">
+          <div id="diagnostic-stub" className="sr-only">Diagnostic form stub endpoint target.</div>
+          <label className="block text-sm font-semibold" htmlFor="problem">Current acquisition problem</label>
+          <textarea id="problem" name="problem" rows={3} className={`mt-2 w-full rounded-lg border border-[#B8C7D9] bg-white px-3 py-3 text-sm ${focusRing}`} placeholder="Lead quality, tracking confidence, AI visibility, paid efficiency..." />
+          <label className="mt-4 block text-sm font-semibold" htmlFor="systems">Systems involved</label>
+          <input id="systems" name="systems" className={`mt-2 w-full rounded-lg border border-[#B8C7D9] bg-white px-3 py-3 text-sm ${focusRing}`} placeholder="Google Ads, GA4, CRM, landing pages, automations" />
+          <div className="mt-4 grid gap-4 sm:grid-cols-2">
+            <label className="block text-sm font-semibold" htmlFor="tracking">Tracking confidence <span className="text-[#596579]">0-10</span><input id="tracking" name="tracking" type="number" min="0" max="10" className={`mt-2 w-full rounded-lg border border-[#B8C7D9] bg-white px-3 py-3 text-sm ${focusRing}`} /></label>
+            <label className="block text-sm font-semibold" htmlFor="clarity">Page clarity <span className="text-[#596579]">0-10</span><input id="clarity" name="clarity" type="number" min="0" max="10" className={`mt-2 w-full rounded-lg border border-[#B8C7D9] bg-white px-3 py-3 text-sm ${focusRing}`} /></label>
+          </div>
+          <button type="submit" className={`mt-5 min-h-11 w-full rounded-lg bg-[#4F46E5] px-5 py-3 text-sm font-semibold text-white transition hover:bg-[#3730A3] ${focusRing}`}>Preview diagnostic request</button>
+          <p className="mt-3 text-xs leading-5 text-[#596579]">Validation states must include text and icon when this becomes a real endpoint.</p>
+        </form>
+      </div>
+    </section>
+  )
+}
+
+function FaqAndFinalCta() {
+  return (
+    <section id="faq" className="bg-[#F7F9FC] px-4 py-20 sm:py-28 lg:px-8">
+      <div className="mx-auto max-w-[980px]">
+        <SectionHeader eyebrow="Risk reversal" title="FAQ for the first diagnostic conversation." />
+        <div className="space-y-3">
+          {faqs.map((faq, index) => (
+            <details key={faq.question} open={index === 0} className={`rounded-2xl border border-[#D8E1EC] bg-white p-5 ${focusRing}`}>
+              <summary className="cursor-pointer text-base font-semibold text-[#0B1020]">{faq.question}</summary>
+              <p className="mt-3 text-sm leading-6 text-[#596579]">{faq.answer}</p>
+            </details>
+          ))}
+        </div>
+        <div className="mt-10 rounded-[1.5rem] border border-[#253250] bg-[#0A0F1F] p-6 text-center text-white shadow-[0_24px_80px_rgba(79,70,229,.22)] sm:p-8">
+          <h2 className="text-3xl font-semibold tracking-[-0.035em]">Find the constraint before you spend around it.</h2>
+          <p className="mx-auto mt-4 max-w-2xl text-sm leading-6 text-[#AEBBD0]">Send the current acquisition problem and the systems involved. We will map the likely leak and recommend the next measurable step.</p>
+          <div className="mt-6 flex flex-col justify-center gap-3 sm:flex-row">
+            <SecondaryLink dark href="#diagnostic">Start the Diagnostic</SecondaryLink>
+            <SecondaryLink dark href="#services">Review Services</SecondaryLink>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export function AgencyHomeShell() {
+  return (
+    <div className="bg-[#F7F9FC] text-[#182033]">
+      <div className="border-b border-[#F8D8A7] bg-[#FFF4DA] px-4 py-3 text-center text-sm font-semibold text-[#A15C07]">
+        Internal staging artifact only — not linked in public navigation and not approved for publication.
+      </div>
+      <header className="sticky top-0 z-40 border-b border-[#D8E1EC] bg-white/90 backdrop-blur-lg">
+        <nav className="mx-auto flex max-w-[1180px] items-center justify-between gap-4 px-4 py-4 lg:px-8" aria-label="Legal Growth OS internal navigation">
+          <Link href="/internal/legal-growth-os" className={`flex items-center gap-3 text-sm font-bold text-[#0B1020] ${focusRing}`}>
+            <span className="grid h-9 w-9 place-items-center rounded-lg bg-[#0A0F1F] text-white">OS</span>
+            <span>Legal Growth OS</span>
+          </Link>
+          <div className="hidden items-center gap-6 lg:flex">
+            <Link href="#services" className={`text-sm font-semibold text-[#596579] hover:text-[#0B1020] ${focusRing}`}>Services</Link>
+            <Link href="#operating-loop" className={`text-sm font-semibold text-[#596579] hover:text-[#0B1020] ${focusRing}`}>Operating Loop</Link>
+            <Link href="#proof" className={`text-sm font-semibold text-[#596579] hover:text-[#0B1020] ${focusRing}`}>Proof</Link>
+            <Link href="#diagnostic" className={`text-sm font-semibold text-[#596579] hover:text-[#0B1020] ${focusRing}`}>Diagnostic</Link>
+            <Link href="#faq" className={`text-sm font-semibold text-[#596579] hover:text-[#0B1020] ${focusRing}`}>FAQ</Link>
+          </div>
+          <div className="hidden items-center gap-3 sm:flex">
+            <SecondaryLink href="#operating-loop">See loop</SecondaryLink>
+            <PrimaryLink href="#diagnostic">Get a Growth Diagnostic</PrimaryLink>
+          </div>
+        </nav>
+      </header>
+      <main>
+        <section className="relative overflow-hidden px-4 py-20 sm:py-28 lg:px-8 lg:py-32">
+          <div className="absolute right-[-18rem] top-[-16rem] h-[34rem] w-[34rem] rounded-full bg-[#E9E7FF] blur-3xl" />
+          <div className="absolute bottom-[-14rem] left-[-16rem] h-[30rem] w-[30rem] rounded-full bg-[#E6F6FE] blur-3xl" />
+          <div className="relative mx-auto grid max-w-[1180px] items-center gap-12 lg:grid-cols-[1.03fr_.97fr]">
+            <div>
+              <p className="text-xs font-bold uppercase tracking-[0.22em] text-[#4F46E5]">Measurement-literate acquisition systems</p>
+              <h1 className="mt-5 max-w-4xl text-[2.55rem] font-semibold leading-[.98] tracking-[-0.045em] text-[#0B1020] sm:text-6xl lg:text-[4.5rem] lg:leading-[.94] lg:tracking-[-0.065em]">Build an acquisition system you can actually measure.</h1>
+              <p className="mt-6 max-w-2xl text-lg leading-8 text-[#596579]">We connect paid media, AI search visibility, landing pages, tracking, and automation so you can see what is producing qualified demand — and what is just spending budget.</p>
+              <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+                <PrimaryLink href="#diagnostic">Get a Growth Diagnostic</PrimaryLink>
+                <SecondaryLink href="#operating-loop">See the operating loop</SecondaryLink>
+              </div>
+              <p className="mt-5 max-w-2xl text-sm leading-6 text-[#596579]">For legal, professional-services, and complex-services teams where lead quality matters more than raw form volume.</p>
+            </div>
+            <HeroLoopCard />
+          </div>
+        </section>
+        <TrustStrip />
+        <ProblemFraming />
+        <ServicesGrid />
+        <ProcessPanel />
+        <CaseStudyModule />
+        <LoopLanes />
+        <DiagnosticForm />
+        <FaqAndFinalCta />
+      </main>
+      <Link href="#diagnostic" className={`fixed inset-x-4 bottom-4 z-50 rounded-xl bg-[#4F46E5] px-5 py-3 text-center text-sm font-semibold text-white shadow-[0_16px_35px_rgba(79,70,229,.32)] sm:hidden ${focusRing}`}>Get Diagnostic</Link>
+    </div>
+  )
+}
+
+export function AgencyTemplatesShell() {
+  return (
+    <div className="bg-[#F7F9FC] px-4 py-16 text-[#182033] lg:px-8">
+      <div className="mx-auto max-w-[1180px]">
+        <div className="rounded-[1.5rem] border border-[#D8E1EC] bg-white p-6 shadow-[0_16px_40px_rgba(25,42,70,.10)] sm:p-8">
+          <p className="text-xs font-bold uppercase tracking-[0.22em] text-[#4F46E5]">Internal template library</p>
+          <h1 className="mt-3 text-4xl font-semibold tracking-[-0.045em] text-[#0B1020] sm:text-5xl">Reusable page shells for service, landing, proof, and intake pages.</h1>
+          <p className="mt-5 max-w-3xl text-base leading-7 text-[#596579]">These modules mirror the Seven handoff and remain staging-only until publication approval. Each template keeps a first-viewport CTA, mid-page diagnostic CTA, proof-safe case slots, and a final conversion panel.</p>
+        </div>
+        <div className="mt-8 grid gap-5 md:grid-cols-2">
+          {templateCards.map((template) => (
+            <article key={template.href} id={template.href.split('#')[1]} className="rounded-[1.125rem] border border-[#D8E1EC] bg-white p-6 shadow-[0_1px_2px_rgba(11,16,32,.06)]">
+              <p className="text-xs font-bold uppercase tracking-[0.18em] text-[#4F46E5]">{template.eyebrow}</p>
+              <h2 className="mt-3 text-2xl font-semibold tracking-[-0.025em] text-[#0B1020]">{template.title}</h2>
+              <p className="mt-3 text-sm leading-6 text-[#596579]">{template.promise}</p>
+              <ul className="mt-5 grid gap-2">
+                {template.modules.map((module) => (
+                  <li key={module} className="rounded-lg border border-[#D8E1EC] bg-[#F7F9FC] px-3 py-2 text-sm text-[#182033]">{module}</li>
+                ))}
+              </ul>
+              <p className="mt-5 text-sm font-semibold text-[#0B1020]">Primary CTA: {template.primaryCta}</p>
+            </article>
+          ))}
+        </div>
+        <div className="mt-8 rounded-[1.5rem] border border-[#253250] bg-[#0A0F1F] p-6 text-white sm:p-8">
+          <p className="text-xs font-bold uppercase tracking-[0.22em] text-[#AEBBD0]">Variant rules</p>
+          <div className="mt-5 grid gap-4 md:grid-cols-3">
+            {[
+              'Swap hero visuals by intent without changing the measurement mechanism.',
+              'Keep numeric proof as empty, caveated slots until source validation and approval exist.',
+              'Forms remain stubbed; no live delivery, CRM write, or external lead capture is connected.',
+            ].map((rule) => (
+              <div key={rule} className="rounded-xl border border-[#253250] bg-[#111B33] p-4 text-sm leading-6 text-[#AEBBD0]">{rule}</div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/AgencySiteShell.tsx
+++ b/src/components/AgencySiteShell.tsx
@@ -7,7 +7,7 @@ function PrimaryLink({ href, children }: { href: string; children: React.ReactNo
   return (
     <Link
       href={href}
-      className={`inline-flex min-h-11 items-center justify-center rounded-lg bg-[#4F46E5] px-5 py-3 text-sm font-semibold text-white shadow-[0_16px_35px_rgba(79,70,229,.22)] transition hover:-translate-y-0.5 hover:bg-[#3730A3] ${focusRing}`}
+      className={`inline-flex min-h-11 items-center justify-center rounded-lg bg-[#4F46E5] px-5 py-3 text-sm font-semibold text-white shadow-[0_16px_35px_rgba(79,70,229,.22)] motion-safe:transition motion-safe:hover:-translate-y-0.5 hover:bg-[#3730A3] ${focusRing}`}
     >
       {children}
     </Link>
@@ -18,7 +18,7 @@ function SecondaryLink({ href, children, dark = false }: { href: string; childre
   return (
     <Link
       href={href}
-      className={`inline-flex min-h-11 items-center justify-center rounded-lg border px-5 py-3 text-sm font-semibold transition hover:-translate-y-0.5 ${focusRing} ${
+      className={`inline-flex min-h-11 items-center justify-center rounded-lg border px-5 py-3 text-sm font-semibold motion-safe:transition motion-safe:hover:-translate-y-0.5 ${focusRing} ${
         dark
           ? 'border-[#253250] bg-white text-[#0A0F1F] hover:border-white'
           : 'border-[#D8E1EC] bg-white text-[#0B1020] hover:border-[#B8C7D9]'
@@ -43,15 +43,15 @@ function HeroLoopCard() {
   const nodes = ['Query intent', 'Landing-page test', 'Qualified lead', 'Budget decision']
 
   return (
-    <div className="relative rounded-[1.5rem] border border-[#D8E1EC] bg-white p-4 shadow-[0_24px_70px_rgba(25,42,70,.16)] sm:p-6">
+    <div className="relative min-w-0 rounded-[1.5rem] border border-[#D8E1EC] bg-white p-4 shadow-[0_24px_70px_rgba(25,42,70,.16)] sm:p-6">
       <div className="flex items-center gap-2 border-b border-[#D8E1EC] pb-4">
         <span className="h-3 w-3 rounded-full bg-[#F87171]" />
         <span className="h-3 w-3 rounded-full bg-[#FBBF24]" />
         <span className="h-3 w-3 rounded-full bg-[#34D399]" />
-        <span className="ml-3 rounded-md border border-[#D8E1EC] bg-[#F7F9FC] px-2 py-1 text-[11px] font-medium text-[#596579]">growth-os.internal/loop</span>
+        <span className="ml-3 min-w-0 truncate rounded-md border border-[#D8E1EC] bg-[#F7F9FC] px-2 py-1 text-[11px] font-medium text-[#596579]">growth-os.internal/loop</span>
       </div>
       <div className="mt-5 rounded-2xl bg-gradient-to-br from-[#F7F9FC] via-white to-[#E6F6FE] p-5">
-        <div className="grid gap-3 sm:grid-cols-2">
+        <div className="grid min-w-0 gap-3 sm:grid-cols-2">
           {nodes.map((node, index) => (
             <div key={node} className="rounded-xl border border-[#D8E1EC] bg-white/90 p-4 shadow-[0_1px_2px_rgba(11,16,32,.06)]">
               <span className="text-[11px] font-bold uppercase tracking-[0.18em] text-[#4F46E5]">0{index + 1}</span>
@@ -126,7 +126,7 @@ function ServicesGrid() {
         <SectionHeader eyebrow="Services" title="Six modules, one acquisition loop." copy="Each card describes the constraint, the system output, and the measurement family instead of a generic service blurb." />
         <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-3">
           {services.map((service) => (
-            <Link key={service.title} href={service.href} className={`group rounded-[1.125rem] border border-[#D8E1EC] bg-white p-6 shadow-[0_1px_2px_rgba(11,16,32,.06)] transition hover:-translate-y-1 hover:border-[#B8C7D9] hover:shadow-[0_16px_40px_rgba(25,42,70,.10)] ${focusRing}`}>
+            <Link key={service.title} href={service.href} className={`group rounded-[1.125rem] border border-[#D8E1EC] bg-white p-6 shadow-[0_1px_2px_rgba(11,16,32,.06)] motion-safe:transition motion-safe:hover:-translate-y-1 hover:border-[#B8C7D9] hover:shadow-[0_16px_40px_rgba(25,42,70,.10)] ${focusRing}`}>
               <p className="text-xs font-bold uppercase tracking-[0.18em] text-[#4F46E5]">{service.constraint}</p>
               <h3 className="mt-4 text-xl font-semibold tracking-[-0.02em] text-[#0B1020]">{service.title}</h3>
               <p className="mt-3 text-sm leading-6 text-[#596579]">{service.output}</p>
@@ -221,10 +221,10 @@ function DiagnosticForm() {
           <h2 className="mt-3 text-3xl font-semibold tracking-[-0.035em]">Start with the constraint, not a retainer pitch.</h2>
           <p className="mt-4 text-base leading-7 text-[#AEBBD0]">No generic audit deck. You get the likely constraint, the evidence behind it, and the next decision it supports.</p>
           <div className="mt-6 rounded-xl border border-[#253250] bg-[#111B33] p-4 text-sm leading-6 text-[#AEBBD0]">
-            Stub only: this internal form uses a GET action back to this route. No live lead capture or outbound delivery is connected.
+            Stub only: this internal form posts to this route without putting values in the URL. No live lead capture, analytics event, or outbound delivery is connected.
           </div>
         </div>
-        <form action="/internal/legal-growth-os#diagnostic-stub" method="get" className="rounded-2xl border border-[#253250] bg-white p-5 text-[#0B1020] sm:p-6">
+        <form action="/internal/legal-growth-os#diagnostic-stub" method="post" className="rounded-2xl border border-[#253250] bg-white p-5 text-[#0B1020] sm:p-6">
           <div id="diagnostic-stub" className="sr-only">Diagnostic form stub endpoint target.</div>
           <label className="block text-sm font-semibold" htmlFor="problem">Current acquisition problem</label>
           <textarea id="problem" name="problem" rows={3} className={`mt-2 w-full rounded-lg border border-[#B8C7D9] bg-white px-3 py-3 text-sm ${focusRing}`} placeholder="Lead quality, tracking confidence, AI visibility, paid efficiency..." />
@@ -234,7 +234,7 @@ function DiagnosticForm() {
             <label className="block text-sm font-semibold" htmlFor="tracking">Tracking confidence <span className="text-[#596579]">0-10</span><input id="tracking" name="tracking" type="number" min="0" max="10" className={`mt-2 w-full rounded-lg border border-[#B8C7D9] bg-white px-3 py-3 text-sm ${focusRing}`} /></label>
             <label className="block text-sm font-semibold" htmlFor="clarity">Page clarity <span className="text-[#596579]">0-10</span><input id="clarity" name="clarity" type="number" min="0" max="10" className={`mt-2 w-full rounded-lg border border-[#B8C7D9] bg-white px-3 py-3 text-sm ${focusRing}`} /></label>
           </div>
-          <button type="submit" className={`mt-5 min-h-11 w-full rounded-lg bg-[#4F46E5] px-5 py-3 text-sm font-semibold text-white transition hover:bg-[#3730A3] ${focusRing}`}>Preview diagnostic request</button>
+          <button type="submit" className={`mt-5 min-h-11 w-full rounded-lg bg-[#4F46E5] px-5 py-3 text-sm font-semibold text-white motion-safe:transition hover:bg-[#3730A3] ${focusRing}`}>Preview diagnostic request</button>
           <p className="mt-3 text-xs leading-5 text-[#596579]">Validation states must include text and icon when this becomes a real endpoint.</p>
         </form>
       </div>
@@ -270,15 +270,15 @@ function FaqAndFinalCta() {
 
 export function AgencyHomeShell() {
   return (
-    <div className="bg-[#F7F9FC] text-[#182033]">
+    <div className="agency-artifact overflow-x-clip bg-[#F7F9FC] text-[#182033]">
       <div className="border-b border-[#F8D8A7] bg-[#FFF4DA] px-4 py-3 text-center text-sm font-semibold text-[#A15C07]">
         Internal staging artifact only — not linked in public navigation and not approved for publication.
       </div>
       <header className="sticky top-0 z-40 border-b border-[#D8E1EC] bg-white/90 backdrop-blur-lg">
-        <nav className="mx-auto flex max-w-[1180px] items-center justify-between gap-4 px-4 py-4 lg:px-8" aria-label="Legal Growth OS internal navigation">
-          <Link href="/internal/legal-growth-os" className={`flex items-center gap-3 text-sm font-bold text-[#0B1020] ${focusRing}`}>
-            <span className="grid h-9 w-9 place-items-center rounded-lg bg-[#0A0F1F] text-white">OS</span>
-            <span>Legal Growth OS</span>
+        <nav className="mx-auto flex max-w-[1180px] items-center justify-between gap-3 px-4 py-4 lg:px-8" aria-label="Legal Growth OS internal navigation">
+          <Link href="/internal/legal-growth-os" className={`flex min-w-0 items-center gap-3 text-sm font-bold text-[#0B1020] ${focusRing}`}>
+            <span className="grid h-9 w-9 shrink-0 place-items-center rounded-lg bg-[#0A0F1F] text-white">OS</span>
+            <span className="min-w-0 truncate">Legal Growth OS</span>
           </Link>
           <div className="hidden items-center gap-6 lg:flex">
             <Link href="#services" className={`text-sm font-semibold text-[#596579] hover:text-[#0B1020] ${focusRing}`}>Services</Link>
@@ -294,13 +294,13 @@ export function AgencyHomeShell() {
         </nav>
       </header>
       <main>
-        <section className="relative overflow-hidden px-4 py-20 sm:py-28 lg:px-8 lg:py-32">
-          <div className="absolute right-[-18rem] top-[-16rem] h-[34rem] w-[34rem] rounded-full bg-[#E9E7FF] blur-3xl" />
-          <div className="absolute bottom-[-14rem] left-[-16rem] h-[30rem] w-[30rem] rounded-full bg-[#E6F6FE] blur-3xl" />
+        <section className="relative overflow-hidden px-4 py-16 sm:py-28 lg:px-8 lg:py-32">
+          <div className="absolute right-0 top-0 h-48 w-48 rounded-full bg-[#E9E7FF] blur-3xl sm:h-[20rem] sm:w-[20rem] lg:right-[-18rem] lg:top-[-16rem] lg:h-[34rem] lg:w-[34rem]" />
+          <div className="absolute bottom-0 left-0 h-44 w-44 rounded-full bg-[#E6F6FE] blur-3xl sm:h-[18rem] sm:w-[18rem] lg:bottom-[-14rem] lg:left-[-16rem] lg:h-[30rem] lg:w-[30rem]" />
           <div className="relative mx-auto grid max-w-[1180px] items-center gap-12 lg:grid-cols-[1.03fr_.97fr]">
             <div>
-              <p className="text-xs font-bold uppercase tracking-[0.22em] text-[#4F46E5]">Measurement-literate acquisition systems</p>
-              <h1 className="mt-5 max-w-4xl text-[2.55rem] font-semibold leading-[.98] tracking-[-0.045em] text-[#0B1020] sm:text-6xl lg:text-[4.5rem] lg:leading-[.94] lg:tracking-[-0.065em]">Build an acquisition system you can actually measure.</h1>
+              <p className="text-xs font-bold uppercase tracking-[0.16em] text-[#4F46E5] sm:tracking-[0.22em]">Measurement-literate acquisition systems</p>
+              <h1 className="mt-5 max-w-4xl text-[2.15rem] font-semibold leading-[1.04] tracking-[-0.035em] text-[#0B1020] sm:text-6xl lg:text-[4.5rem] lg:leading-[.94] lg:tracking-[-0.065em]">Build an acquisition system you can actually measure.</h1>
               <p className="mt-6 max-w-2xl text-lg leading-8 text-[#596579]">We connect paid media, AI search visibility, landing pages, tracking, and automation so you can see what is producing qualified demand — and what is just spending budget.</p>
               <div className="mt-8 flex flex-col gap-3 sm:flex-row">
                 <PrimaryLink href="#diagnostic">Get a Growth Diagnostic</PrimaryLink>
@@ -327,11 +327,11 @@ export function AgencyHomeShell() {
 
 export function AgencyTemplatesShell() {
   return (
-    <div className="bg-[#F7F9FC] px-4 py-16 text-[#182033] lg:px-8">
+    <div className="agency-artifact overflow-x-clip bg-[#F7F9FC] px-4 py-12 text-[#182033] sm:py-16 lg:px-8">
       <div className="mx-auto max-w-[1180px]">
         <div className="rounded-[1.5rem] border border-[#D8E1EC] bg-white p-6 shadow-[0_16px_40px_rgba(25,42,70,.10)] sm:p-8">
-          <p className="text-xs font-bold uppercase tracking-[0.22em] text-[#4F46E5]">Internal template library</p>
-          <h1 className="mt-3 text-4xl font-semibold tracking-[-0.045em] text-[#0B1020] sm:text-5xl">Reusable page shells for service, landing, proof, and intake pages.</h1>
+          <p className="text-xs font-bold uppercase tracking-[0.16em] text-[#4F46E5] sm:tracking-[0.22em]">Internal template library</p>
+          <h1 className="mt-3 text-3xl font-semibold leading-tight tracking-[-0.035em] text-[#0B1020] sm:text-5xl sm:tracking-[-0.045em]">Reusable page shells for service, landing, proof, and intake pages.</h1>
           <p className="mt-5 max-w-3xl text-base leading-7 text-[#596579]">These modules mirror the Seven handoff and remain staging-only until publication approval. Each template keeps a first-viewport CTA, mid-page diagnostic CTA, proof-safe case slots, and a final conversion panel.</p>
         </div>
         <div className="mt-8 grid gap-5 md:grid-cols-2">
@@ -345,7 +345,7 @@ export function AgencyTemplatesShell() {
                   <li key={module} className="rounded-lg border border-[#D8E1EC] bg-[#F7F9FC] px-3 py-2 text-sm text-[#182033]">{module}</li>
                 ))}
               </ul>
-              <p className="mt-5 text-sm font-semibold text-[#0B1020]">Primary CTA: {template.primaryCta}</p>
+              <a href={template.href} className={`mt-5 inline-flex min-h-11 items-center rounded-lg border border-[#D8E1EC] bg-[#F7F9FC] px-4 py-2 text-sm font-semibold text-[#0B1020] hover:border-[#B8C7D9] ${focusRing}`}>Primary CTA: {template.primaryCta}</a>
             </article>
           ))}
         </div>

--- a/src/components/AnalyticsGate.tsx
+++ b/src/components/AnalyticsGate.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import Script from 'next/script'
+import { usePathname } from 'next/navigation'
+import GoogleAnalytics from '@/components/GoogleAnalytics'
+
+const GTM_ID = 'GTM-TMZRCGT'
+const INTERNAL_ANALYTICS_BLOCKLIST = ['/internal/legal-growth-os']
+
+function analyticsAllowed(pathname: string | null) {
+  return !INTERNAL_ANALYTICS_BLOCKLIST.some((prefix) => pathname?.startsWith(prefix))
+}
+
+export function AnalyticsGate() {
+  const pathname = usePathname()
+
+  if (!analyticsAllowed(pathname)) {
+    return null
+  }
+
+  return (
+    <>
+      <Script
+        id="gtm-script"
+        strategy="afterInteractive"
+        dangerouslySetInnerHTML={{
+          __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','${GTM_ID}');`,
+        }}
+      />
+      <GoogleAnalytics />
+    </>
+  )
+}

--- a/src/components/GoogleAnalytics.tsx
+++ b/src/components/GoogleAnalytics.tsx
@@ -10,8 +10,12 @@ function GoogleAnalyticsInner() {
   const searchParams = useSearchParams()
 
   useEffect(() => {
+    if (pathname?.startsWith('/internal/legal-growth-os')) {
+      return
+    }
+
     if (pathname) {
-      pageview(pathname + (searchParams?.toString() ? `?${searchParams.toString()}` : ''))
+      pageview(pathname)
     }
   }, [pathname, searchParams])
 

--- a/src/components/SiteChrome.tsx
+++ b/src/components/SiteChrome.tsx
@@ -9,7 +9,7 @@ export function SiteChrome({ children }: { children: React.ReactNode }) {
   const isInternalAgencyArtifact = pathname?.startsWith('/internal/legal-growth-os')
 
   if (isInternalAgencyArtifact) {
-    return <main className="flex-1">{children}</main>
+    return <div className="flex-1">{children}</div>
   }
 
   return (

--- a/src/components/SiteChrome.tsx
+++ b/src/components/SiteChrome.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import { Footer } from '@/components/Footer'
+import { Navbar } from '@/components/Navbar'
+
+export function SiteChrome({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname()
+  const isInternalAgencyArtifact = pathname?.startsWith('/internal/legal-growth-os')
+
+  if (isInternalAgencyArtifact) {
+    return <main className="flex-1">{children}</main>
+  }
+
+  return (
+    <>
+      <Navbar />
+      <main className="flex-1">{children}</main>
+      <Footer />
+    </>
+  )
+}

--- a/src/lib/agency-site-content.ts
+++ b/src/lib/agency-site-content.ts
@@ -1,0 +1,189 @@
+export type ServiceCard = {
+  title: string
+  constraint: string
+  output: string
+  tags: string[]
+  href: string
+}
+
+export type ProcessStep = {
+  step: string
+  title: string
+  copy: string
+}
+
+export type TemplateCard = {
+  title: string
+  href: string
+  eyebrow: string
+  promise: string
+  modules: string[]
+  primaryCta: string
+}
+
+export const agencyTokens = {
+  color: {
+    primary: '#4F46E5',
+    canvas: '#F7F9FC',
+    surface: '#FFFFFF',
+    surfaceMuted: '#EEF3F8',
+    ink: '#0B1020',
+    text: '#182033',
+    textMuted: '#596579',
+    border: '#D8E1EC',
+    borderStrong: '#B8C7D9',
+    accentHover: '#3730A3',
+    accentSoft: '#E9E7FF',
+    cyan: '#0EA5E9',
+    cyanSoft: '#E6F6FE',
+    proofPanel: '#0A0F1F',
+    proofPanelRaised: '#111B33',
+    proofBorder: '#253250',
+    proofText: '#F8FAFC',
+    proofTextMuted: '#AEBBD0',
+    warning: '#A15C07',
+    warningSoft: '#FFF4DA',
+    danger: '#B42318',
+  },
+  radius: {
+    md: '0.5rem',
+    lg: '0.75rem',
+    xl: '1.125rem',
+    panel: '1.5rem',
+  },
+  shadow: {
+    card: '0 16px 40px rgba(25,42,70,.10)',
+    panel: '0 24px 80px rgba(79,70,229,.22)',
+  },
+} as const
+
+export const proofStrip = [
+  { label: 'CPA', detail: 'Judged against qualified demand, not raw form volume.' },
+  { label: 'CRM', detail: 'Lead-quality feedback belongs in the operating loop.' },
+  { label: 'AI', detail: 'Visibility is measured by documented method.' },
+  { label: 'Tests', detail: 'Offers, pages, queries, and budget decisions move together.' },
+]
+
+export const services: ServiceCard[] = [
+  {
+    title: 'Paid Media / SEM',
+    constraint: 'Spend is moving but qualified demand is not clear.',
+    output: 'Campaign, query, page, and CRM feedback loops managed against economics.',
+    tags: ['Search terms', 'Intent tiers', 'Qualified leads'],
+    href: '/internal/legal-growth-os/templates#paid-media',
+  },
+  {
+    title: 'AI Search / SEO',
+    constraint: 'Buyers and answer engines do not find the right proof.',
+    output: 'Commercial query maps, entity cleanup, citation gaps, and visibility scans.',
+    tags: ['AI answers', 'Entity signals', 'Commercial pages'],
+    href: '/internal/legal-growth-os/templates#ai-search',
+  },
+  {
+    title: 'Creative + Landing Pages',
+    constraint: 'Ad intent and page promise are not aligned tightly enough.',
+    output: 'Offer clarity, proof-safe page modules, and measurable landing-page tests.',
+    tags: ['CRO', 'Offer tests', 'Message fit'],
+    href: '/internal/legal-growth-os/templates#landing-pages',
+  },
+  {
+    title: 'Analytics / Attribution',
+    constraint: 'Dashboards show activity but not operating decisions.',
+    output: 'UTMs, events, CRM lifecycle states, and decision-grade reporting hygiene.',
+    tags: ['UTM governance', 'Events', 'Dashboards'],
+    href: '/internal/legal-growth-os/templates#analytics',
+  },
+  {
+    title: 'Agency OS / Automation',
+    constraint: 'Manual handoffs slow follow-up and hide signal.',
+    output: 'Automation, routing, alerts, and feedback capture across the acquisition system.',
+    tags: ['Workflows', 'Routing', 'Feedback'],
+    href: '/internal/legal-growth-os/templates#automation',
+  },
+  {
+    title: 'Growth Diagnostic',
+    constraint: 'The next move is unclear and the budget risk is real.',
+    output: 'A constraint map, evidence summary, next action, and claim-risk notes.',
+    tags: ['Constraint map', 'Evidence', 'Next decision'],
+    href: '#diagnostic',
+  },
+]
+
+export const processSteps: ProcessStep[] = [
+  { step: '01', title: 'Diagnose', copy: 'Name the acquisition constraint before prescribing channels.' },
+  { step: '02', title: 'Instrument', copy: 'Make tracking, source data, and lead-quality feedback trustworthy enough to use.' },
+  { step: '03', title: 'Build', copy: 'Create the pages, campaigns, automations, and scorecards the loop requires.' },
+  { step: '04', title: 'Launch', copy: 'Ship controlled tests with clean UTMs, events, and decision rules.' },
+  { step: '05', title: 'Measure', copy: 'Read qualified demand, caveats, and spend signals together.' },
+  { step: '06', title: 'Iterate', copy: 'Move budget and effort toward the constraint that evidence supports.' },
+]
+
+export const templateCards: TemplateCard[] = [
+  {
+    title: 'Core services overview',
+    href: '/internal/legal-growth-os/templates#services-overview',
+    eyebrow: 'Acquisition system services',
+    promise: 'Services built around the acquisition constraint.',
+    modules: ['Constraint selector', 'Service grid', 'Comparison table', 'Operating loop', 'Diagnostic CTA'],
+    primaryCta: 'Find the Constraint',
+  },
+  {
+    title: 'AI Search / GEO / SEO',
+    href: '/internal/legal-growth-os/templates#ai-search',
+    eyebrow: 'AI search + commercial SEO',
+    promise: 'Be visible where buyers and AI systems build the shortlist.',
+    modules: ['Pain cards', 'Visibility scan', 'Commercial query map', 'Proof-safe case card'],
+    primaryCta: 'Run an AI Visibility Scan',
+  },
+  {
+    title: 'SEM / paid media management',
+    href: '/internal/legal-growth-os/templates#paid-media',
+    eyebrow: 'Paid media + lead-quality measurement',
+    promise: 'Paid media managed against qualified demand, not dashboard comfort.',
+    modules: ['Intent stack', 'Search-term leak table', 'Measurement panel', 'Service scope'],
+    primaryCta: 'Request a Paid Media Review',
+  },
+  {
+    title: 'Landing pages + CRO',
+    href: '/internal/legal-growth-os/templates#landing-pages',
+    eyebrow: 'Landing-page conversion systems',
+    promise: 'Turn ad intent into a page experience that can be measured.',
+    modules: ['Offer clarity', 'Proof fit', 'Friction reduction', 'Experiment plan'],
+    primaryCta: 'Get a Landing Page Teardown',
+  },
+  {
+    title: 'Analytics / attribution / tracking',
+    href: '/internal/legal-growth-os/templates#analytics',
+    eyebrow: 'Decision-grade measurement',
+    promise: 'Make source, event, and lead-quality data usable for budget decisions.',
+    modules: ['Tracking map', 'Event taxonomy', 'CRM feedback', 'Dashboard hygiene'],
+    primaryCta: 'Audit Tracking Confidence',
+  },
+  {
+    title: 'Automation / Agency OS',
+    href: '/internal/legal-growth-os/templates#automation',
+    eyebrow: 'Marketing automation + Agency OS',
+    promise: 'Keep follow-up, routing, and feedback loops from depending on memory.',
+    modules: ['Routing rules', 'Nurture paths', 'Alerts', 'Ops scorecard'],
+    primaryCta: 'Map the Automation Loop',
+  },
+]
+
+export const faqs = [
+  {
+    question: 'What if spend is too small for signal?',
+    answer: 'The diagnostic still maps the likely constraint, but decisions are framed as instrumentation and test-readiness before any aggressive budget move.',
+  },
+  {
+    question: 'How fast can a diagnostic move?',
+    answer: 'The shell presents a focused intake path: current acquisition problem, systems involved, tracking confidence, and page/offer clarity.',
+  },
+  {
+    question: 'What access is usually needed?',
+    answer: 'Ad accounts, analytics, landing-page/CMS access, CRM lifecycle fields, and any existing call or consult-quality feedback.',
+  },
+  {
+    question: 'How is confidentiality handled?',
+    answer: 'The template avoids client-identifying proof and numeric outcomes until evidence source, redaction, claim risk, and approval are complete.',
+  },
+]


### PR DESCRIPTION
## Summary
- Adds internal-only Legal Growth OS homepage shell at `/internal/legal-growth-os` using Seven's design/token handoffs.
- Adds reusable internal template library at `/internal/legal-growth-os/templates` for services, AI search/SEO, paid media, CRO, analytics, and automation variants.
- Adds proof-safe modules, responsive grids, visible focus treatment, noindex metadata, and a diagnostic form stub that submits via GET back to the same internal route.
- Hides the public LexyAlgo navbar/footer on the internal agency artifacts so no newsletter/contact live capture appears on the staging shell.

## Proof
- `npm run lint`
- `npm run build`
- Browser preview: `http://localhost:4173/internal/legal-growth-os`
- Browser preview: `http://localhost:4173/internal/legal-growth-os/templates`
- Browser vision verified the homepage renders without major desktop layout defects and that no live capture form appears outside the diagnostic stub.

## Notes
- Internal/staging artifact only; not linked from public navigation and not approved for publication.
- No public numeric proof, testimonials, client identifiers, or live lead capture were added.

Closes #72
