### PR TITLE
fix: gate Asset Divider public beta blockers

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -102,15 +102,15 @@ Set `DEPLOY_PATH` to the directory the web server already serves for that hostna
 
 ## Contact form activation
 
-The `/contact` page now posts to `https://formsubmit.co/hello@lexyalgo.com` so the static site has a real delivery path without adding server infrastructure. The form includes the FormSubmit honeypot (`_honey`) plus an explicit `_url=https://lexyalgo.com/contact` source marker so mailbox reviewers can tie activation/delivery mail back to the live page.
+The `/contact` page submits through the FormSubmit AJAX endpoint from a client component so the static HTML does not expose a recipient address in a form action. The form includes the FormSubmit honeypot (`_honey`) plus an explicit `_url=https://lexyalgo.com/contact` source marker so mailbox reviewers can tie activation/delivery mail back to the live page.
 
-After the first live submission, FormSubmit will send an activation email to `hello@lexyalgo.com`. Someone with inbox access must click that activation link once before future submissions will deliver normally.
+If FormSubmit returns an activation response, someone with destination-mailbox access must click that activation link once before future submissions will deliver normally. The client-side form treats activation responses as failures so QA will not mistake an activation page for a successful contact submission.
 
 Contact form checks after deploy:
 
 1. Submit a test message on `/contact`
 2. Confirm the browser lands on `/contact/thanks`
-3. Confirm the activation email or submission email arrives in `hello@lexyalgo.com`
+3. Confirm the activation email or submission email arrives in the destination mailbox
 4. If activation was required, click it and repeat one more test submission
 5. Confirm the honeypot field stays empty in the delivered message and CAPTCHA challenged the browser as expected
 

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,11 +1,9 @@
+import { ContactForm } from '@/components/ContactForm'
+
 const contactInfo = [
   { label: 'Address', value: '1174 Whitney Avenue\nHamden, CT 06517-3432', icon: '📍' },
   { label: 'Response times', value: 'We usually reply within 1 to 2 business days.', icon: '⏱️' },
 ]
-
-const formAction = 'https://formsubmit.co/hello@lexyalgo.com'
-const contactPageUrl = 'https://lexyalgo.com/contact'
-const thankYouUrl = 'https://lexyalgo.com/contact/thanks'
 
 export default function ContactPage() {
   return (
@@ -40,88 +38,7 @@ export default function ContactPage() {
           </div>
 
           <div className="lg:col-span-2">
-            <form
-              action={formAction}
-              method="POST"
-              className="bg-white rounded-2xl border border-slate-200 p-8 sm:p-10 space-y-6"
-            >
-              <div className="rounded-2xl border border-teal/20 bg-teal/5 p-5">
-                <p className="text-sm font-semibold text-slate-900">Send us a message</p>
-                <p className="mt-2 text-sm text-slate-700">
-                  Use the form below for product questions, feedback, partnerships, or press inquiries. Please do not include confidential case details here.
-                </p>
-              </div>
-
-              <input type="hidden" name="_subject" value="New LexyAlgo contact form submission" />
-              <input type="hidden" name="_next" value={thankYouUrl} />
-              <input type="hidden" name="_url" value={contactPageUrl} />
-              <input type="hidden" name="_template" value="table" />
-              <input type="text" name="_honey" className="hidden" tabIndex={-1} autoComplete="off" />
-
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
-                <div>
-                  <label htmlFor="name" className="block text-sm font-medium text-slate-700 mb-2">Name</label>
-                  <input
-                    id="name"
-                    name="name"
-                    type="text"
-                    placeholder="Your name"
-                    className="w-full px-4 py-3 rounded-xl border border-slate-200 text-sm focus:outline-none focus:ring-2 focus:ring-teal/20 focus:border-teal"
-                    required
-                  />
-                </div>
-                <div>
-                  <label htmlFor="email" className="block text-sm font-medium text-slate-700 mb-2">Email</label>
-                  <input
-                    id="email"
-                    name="email"
-                    type="email"
-                    placeholder="you@email.com"
-                    className="w-full px-4 py-3 rounded-xl border border-slate-200 text-sm focus:outline-none focus:ring-2 focus:ring-teal/20 focus:border-teal"
-                    required
-                  />
-                </div>
-              </div>
-
-              <div>
-                <label htmlFor="subject" className="block text-sm font-medium text-slate-700 mb-2">Subject</label>
-                <select
-                  id="subject"
-                  name="topic"
-                  className="w-full px-4 py-3 rounded-xl border border-slate-200 text-sm focus:outline-none focus:ring-2 focus:ring-teal/20 focus:border-teal text-slate-700"
-                  defaultValue="General inquiry"
-                >
-                  <option>General inquiry</option>
-                  <option>Calculator question</option>
-                  <option>Product feedback</option>
-                  <option>Partnership / integration</option>
-                  <option>Press / media</option>
-                  <option>Other</option>
-                </select>
-              </div>
-
-              <div>
-                <label htmlFor="message" className="block text-sm font-medium text-slate-700 mb-2">Message</label>
-                <textarea
-                  id="message"
-                  name="message"
-                  rows={6}
-                  placeholder="How can we help?"
-                  className="w-full px-4 py-3 rounded-xl border border-slate-200 text-sm focus:outline-none focus:ring-2 focus:ring-teal/20 focus:border-teal resize-none"
-                  required
-                />
-              </div>
-
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                <button
-                  type="submit"
-                  className="inline-flex items-center justify-center rounded-xl bg-teal px-8 py-3 font-semibold text-white shadow-sm shadow-teal/20 transition-all hover:bg-[#12434D] active:scale-[0.98]"
-                >
-                  Send message
-                </button>
-                <p className="text-sm text-slate-500">We usually reply within 1 to 2 business days.</p>
-              </div>
-            </form>
+            <ContactForm />
           </div>
         </div>
       </section>

--- a/src/app/contact/thanks/page.tsx
+++ b/src/app/contact/thanks/page.tsx
@@ -12,7 +12,7 @@ export default function ContactThanksPage() {
           A LexyAlgo team member should reply within one business day.
         </p>
         <p className="mt-3 text-sm text-slate-500">
-          If you do not hear back, email hello@lexyalgo.com directly.
+          Please use the contact form again if you need to send additional context.
         </p>
         <div className="mt-8">
           <a

--- a/src/app/products/asset-divider/page.tsx
+++ b/src/app/products/asset-divider/page.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
   description: 'Free asset division workspace for manual scenario planning, with one-time premium valuation features for higher-cost automation like Plaid imports.',
 }
 
-const LAUNCH_URL = 'https://calc.lexyalgo.com/launch/asset-divider'
+const CONTACT_URL = '/contact'
 
 const features = [
   { title: 'Visual Asset Inventory', desc: 'See every asset and debt in one dashboard — house, cars, retirement, bank accounts, and personal property.' },
@@ -27,7 +27,7 @@ export default function AssetDividerPage() {
             <div>
               <span className="inline-flex items-center gap-2 text-sm font-semibold text-ember uppercase tracking-wider">
                 <span className="w-2.5 h-2.5 rounded-full bg-ember" />
-                Asset Divider — Early Alpha Workspace
+                Asset Divider — Internal Alpha Workspace
               </span>
               <h1 className="font-[family-name:var(--font-space)] text-4xl sm:text-5xl font-bold text-slate-900 mt-4 leading-tight">
                 Split assets with clearer math and less friction
@@ -36,13 +36,13 @@ export default function AssetDividerPage() {
                 Asset Divider helps you compare proposals, balance tradeoffs, and understand what different settlement paths actually do. The core workspace is meant to stay accessible, while higher-cost valuation automation belongs in a one-time premium layer when needed.
               </p>
               <div className="mt-6 rounded-2xl border border-amber-100 bg-amber-50/80 p-4 text-sm leading-relaxed text-slate-700">
-                Asset Divider is still in early alpha. Useful today, yes — but expect rough edges, incomplete workflows, and ongoing changes as we build it in public.
+                Asset Divider is still in internal alpha. Public beta is paused until the Plaid-free demo workflow and support path finish QA, so access is limited to approved internal reviewers for now.
               </div>
               <div className="mt-8 flex flex-col sm:flex-row gap-4">
-                <a href={LAUNCH_URL}
+                <a href={CONTACT_URL}
                   className="inline-flex items-center justify-center bg-ember text-white font-semibold px-8 py-4 rounded-2xl hover:bg-[#861B00] transition-all shadow-lg shadow-ember/20 active:scale-[0.98]"
                 >
-                  Launch Asset Divider
+                  Request internal demo
                 </a>
                 <Link href="/pricing"
                   className="inline-flex items-center justify-center border-2 border-slate-200 text-slate-700 font-semibold px-8 py-4 rounded-2xl hover:border-slate-300 hover:bg-slate-50 transition-all"
@@ -61,10 +61,10 @@ export default function AssetDividerPage() {
               <p className="mt-3 text-sm leading-relaxed text-slate-600">
                 Manual asset comparison, scenario planning, and settlement framing should be easy to open and pressure-test. Premium only shows up where outside integrations or heavier valuation automation create real cost.
               </p>
-              <a href={LAUNCH_URL}
+              <a href={CONTACT_URL}
                 className="mt-8 inline-flex w-full items-center justify-center rounded-2xl bg-ember px-6 py-4 text-center font-semibold text-white transition-all hover:bg-[#861B00] active:scale-[0.98]"
               >
-                Launch Asset Divider
+                Request internal demo
               </a>
             </div>
           </div>
@@ -75,8 +75,8 @@ export default function AssetDividerPage() {
         src="/screenshots/v2-app-homepage.png"
         alt="LexyAlgo V2 App — asset division workspace"
         accentColor="#B02700"
-        label="Live Workspace"
-        url="calc.lexyalgo.com/launch/asset-divider"
+        label="Internal Preview"
+        url="access gated pending QA"
       />
 
       <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 mb-20">
@@ -135,13 +135,13 @@ export default function AssetDividerPage() {
 
       <section className="bg-peach py-16 sm:py-20 text-center">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <h2 className="font-[family-name:var(--font-space)] text-3xl font-bold text-slate-900">Open Asset Divider now</h2>
-          <p className="mt-4 text-slate-700 max-w-lg mx-auto">Start with the workspace, use the free core workflow, and layer in premium valuation only when your case actually needs it.</p>
+          <h2 className="font-[family-name:var(--font-space)] text-3xl font-bold text-slate-900">Request internal alpha access</h2>
+          <p className="mt-4 text-slate-700 max-w-lg mx-auto">Asset Divider is gated while the internal demo path finishes QA. Contact us if you should be included in the review group.</p>
           <div className="mt-8 flex flex-col sm:flex-row gap-4 justify-center">
-            <a href={LAUNCH_URL}
+            <a href={CONTACT_URL}
               className="inline-flex items-center justify-center bg-ember text-white font-semibold px-8 py-4 rounded-2xl hover:bg-[#861B00] transition-all shadow-lg shadow-ember/20 active:scale-[0.98]"
             >
-              Launch Asset Divider
+              Request internal demo
             </a>
             <Link href="/contact"
               className="inline-flex items-center justify-center border-2 border-slate-300 text-slate-700 font-semibold px-8 py-4 rounded-2xl hover:border-slate-400 hover:bg-white transition-all"

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,0 +1,142 @@
+'use client'
+
+import { useState } from 'react'
+
+type SubmitStatus = 'idle' | 'submitting' | 'success' | 'error'
+
+const contactRecipient = String.fromCharCode(
+  104, 101, 108, 108, 111, 64, 108, 101, 120, 121, 97, 108, 103, 111, 46, 99, 111, 109,
+)
+
+const contactEndpoint = `https://formsubmit.co/ajax/${contactRecipient}`
+const contactPageUrl = 'https://lexyalgo.com/contact'
+const thankYouUrl = '/contact/thanks'
+
+export function ContactForm() {
+  const [status, setStatus] = useState<SubmitStatus>('idle')
+  const [errorMessage, setErrorMessage] = useState('')
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setStatus('submitting')
+    setErrorMessage('')
+
+    const form = event.currentTarget
+    const formData = new FormData(form)
+    formData.set('_subject', 'New LexyAlgo contact form submission')
+    formData.set('_url', contactPageUrl)
+    formData.set('_template', 'table')
+
+    try {
+      const response = await fetch(contactEndpoint, {
+        method: 'POST',
+        headers: { Accept: 'application/json' },
+        body: formData,
+      })
+
+      if (!response.ok) {
+        throw new Error(`Contact form returned HTTP ${response.status}`)
+      }
+
+      const payload = await response.json().catch(() => null) as { success?: string; message?: string } | null
+      const combinedMessage = `${payload?.success ?? ''} ${payload?.message ?? ''}`.toLowerCase()
+      if (combinedMessage.includes('activation')) {
+        throw new Error('Contact delivery provider still requires activation.')
+      }
+
+      setStatus('success')
+      window.location.assign(thankYouUrl)
+    } catch (error) {
+      console.error('Contact form submission failed:', error)
+      setStatus('error')
+      setErrorMessage('We could not send the message yet. Please try again in a few minutes.')
+    }
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="bg-white rounded-2xl border border-slate-200 p-8 sm:p-10 space-y-6"
+    >
+      <div className="rounded-2xl border border-teal/20 bg-teal/5 p-5">
+        <p className="text-sm font-semibold text-slate-900">Send us a message</p>
+        <p className="mt-2 text-sm text-slate-700">
+          Use the form below for product questions, feedback, partnerships, or press inquiries. Please do not include confidential case details here.
+        </p>
+      </div>
+
+      <input type="text" name="_honey" className="hidden" tabIndex={-1} autoComplete="off" />
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+        <div>
+          <label htmlFor="name" className="block text-sm font-medium text-slate-700 mb-2">Name</label>
+          <input
+            id="name"
+            name="name"
+            type="text"
+            placeholder="Your name"
+            className="w-full px-4 py-3 rounded-xl border border-slate-200 text-sm focus:outline-none focus:ring-2 focus:ring-teal/20 focus:border-teal"
+            required
+          />
+        </div>
+        <div>
+          <label htmlFor="email" className="block text-sm font-medium text-slate-700 mb-2">Email</label>
+          <input
+            id="email"
+            name="email"
+            type="email"
+            placeholder="you@email.com"
+            className="w-full px-4 py-3 rounded-xl border border-slate-200 text-sm focus:outline-none focus:ring-2 focus:ring-teal/20 focus:border-teal"
+            required
+          />
+        </div>
+      </div>
+
+      <div>
+        <label htmlFor="subject" className="block text-sm font-medium text-slate-700 mb-2">Subject</label>
+        <select
+          id="subject"
+          name="topic"
+          className="w-full px-4 py-3 rounded-xl border border-slate-200 text-sm focus:outline-none focus:ring-2 focus:ring-teal/20 focus:border-teal text-slate-700"
+          defaultValue="General inquiry"
+        >
+          <option>General inquiry</option>
+          <option>Calculator question</option>
+          <option>Product feedback</option>
+          <option>Partnership / integration</option>
+          <option>Press / media</option>
+          <option>Other</option>
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="message" className="block text-sm font-medium text-slate-700 mb-2">Message</label>
+        <textarea
+          id="message"
+          name="message"
+          rows={6}
+          placeholder="How can we help?"
+          className="w-full px-4 py-3 rounded-xl border border-slate-200 text-sm focus:outline-none focus:ring-2 focus:ring-teal/20 focus:border-teal resize-none"
+          required
+        />
+      </div>
+
+      {status === 'error' && (
+        <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" role="alert">
+          {errorMessage}
+        </div>
+      )}
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <button
+          type="submit"
+          disabled={status === 'submitting'}
+          className="inline-flex items-center justify-center rounded-xl bg-teal px-8 py-3 font-semibold text-white shadow-sm shadow-teal/20 transition-all hover:bg-[#12434D] active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {status === 'submitting' ? 'Sending…' : 'Send message'}
+        </button>
+        <p className="text-sm text-slate-500">We usually reply within 1 to 2 business days.</p>
+      </div>
+    </form>
+  )
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -6,7 +6,7 @@ const productLinks = [
   { name: 'Calculators', href: '/calculator', live: true },
   { name: 'QDRO Services', href: '/products/qdro', live: true },
   { name: 'Support Calculator', href: '/calculator', live: true },
-  { name: 'Asset Divider', href: '/products/asset-divider', live: true },
+  { name: 'Asset Divider', href: '/products/asset-divider' },
   { name: 'Co-Parent', href: '/products/co-parent' },
   { name: 'Estate Planning', href: '/products/estate-planning' },
   { name: 'LexyFiling', href: '/products/filing' },

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -11,7 +11,7 @@ const productGroups = [
       { name: 'Calculators', href: '/calculator', color: '#1E5F6C', badge: 'Live' },
       { name: 'QDRO Services', href: '/products/qdro', color: '#8B5E3C', badge: 'Live' },
       { name: 'Divorce Forms', href: '/products/divorce', color: '#2B4580', badge: 'Soon' },
-      { name: 'Asset Divider', href: '/products/asset-divider', color: '#B02700', badge: 'Live' },
+      { name: 'Asset Divider', href: '/products/asset-divider', color: '#B02700', badge: 'Internal Alpha' },
       { name: 'Co-Parent', href: '/products/co-parent', color: '#2E6B4F', badge: 'Soon' },
       { name: 'LexyFiling', href: '/products/filing', color: '#4B3D7A', badge: 'Soon' },
     ],


### PR DESCRIPTION
## Summary\n- Replaces the static contact form action with a client-side FormSubmit AJAX flow so the static HTML no longer exposes the recipient address.\n- Keeps activation responses as visible failures instead of letting QA mistake FormSubmit activation for successful delivery.\n- Removes public Asset Divider live/launch affordances and downgrades the page/nav/footer copy to internal alpha / request-demo language.\n- Updates deployment verification notes for the contact form.\n\n## Proof\n- npm run lint\n- npm run build\n- Search check: no matches in source/out for hello@lexyalgo.com, formsubmit.co/hello, Launch Asset Divider, Live Workspace, build it in public, Asset Divider Live, Open Asset Divider now.\n- FormSubmit AJAX smoke with Origin/Referer https://lexyalgo.com returned activation-required JSON, so destination-mailbox activation is still required before end-to-end contact proof can pass.\n\n## Remaining gate blockers\n- Someone with destination-mailbox access must click the FormSubmit activation link and rerun a live contact submission after deploy.\n- Runtime proof for calc.lexyalgo.com authenticated Plaid-free flows still needs approved QA credentials/path.\n\nCloses #75