### PR TITLE
Hide contact recipient from static source

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -100,17 +100,17 @@ If `DEPLOY_CONTAINER` is not set, the workflow replaces the configured host path
 
 Set `DEPLOY_PATH` to the directory the web server already serves for that hostname.
 
-## Contact form activation
+## Contact form delivery
 
-The `/contact` page now posts to `https://formsubmit.co/hello@lexyalgo.com` so the static site has a real delivery path without adding server infrastructure. The form includes the FormSubmit honeypot (`_honey`) plus an explicit `_url=https://lexyalgo.com/contact` source marker so mailbox reviewers can tie activation/delivery mail back to the live page.
+The `/contact` page submits through the FormSubmit AJAX endpoint from a client component so static HTML does not expose a destination mailbox in a form action. The form includes the FormSubmit honeypot (`_honey`) plus an explicit `_url=https://lexyalgo.com/contact` source marker so mailbox reviewers can tie activation/delivery mail back to the live page.
 
-After the first live submission, FormSubmit will send an activation email to `hello@lexyalgo.com`. Someone with inbox access must click that activation link once before future submissions will deliver normally.
+If FormSubmit returns an activation or non-OK response, the client-side form shows a failure message instead of sending the visitor to the thank-you page. Only successful AJAX responses redirect to `/contact/thanks`.
 
 Contact form checks after deploy:
 
 1. Submit a test message on `/contact`
 2. Confirm the browser lands on `/contact/thanks`
-3. Confirm the activation email or submission email arrives in `hello@lexyalgo.com`
+3. Confirm the activation email or submission email arrives in the destination mailbox
 4. If activation was required, click it and repeat one more test submission
 5. Confirm the honeypot field stays empty in the delivered message and CAPTCHA challenged the browser as expected
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "tinacms build --local --skip-cloud-checks && next build",
     "start": "next start",
     "lint": "tsc --noEmit -p tsconfig.lint.json",
+    "test:contact-form": "node scripts/check-contact-form-privacy.mjs",
     "verify:shared-auth-links": "node scripts/verify-shared-auth-links.mjs"
   },
   "keywords": [],

--- a/scripts/check-contact-form-privacy.mjs
+++ b/scripts/check-contact-form-privacy.mjs
@@ -1,0 +1,94 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+
+const repoRoot = process.cwd()
+const recipient = ['he', 'llo', '@', 'lexy', 'algo', '.', 'com'].join('')
+const directProviderPath = ['formsubmit.co/', recipient].join('')
+const checkedRoots = ['src', 'docs', '.next/server', '.next/static']
+const ignoredDirs = new Set(['.git', 'node_modules', '.next/cache'])
+const textExtensions = new Set([
+  '.css',
+  '.html',
+  '.js',
+  '.json',
+  '.mjs',
+  '.md',
+  '.rsc',
+  '.txt',
+  '.ts',
+  '.tsx',
+])
+
+function extensionOf(filePath) {
+  const basename = filePath.split('/').pop() ?? ''
+  const dotIndex = basename.lastIndexOf('.')
+  return dotIndex === -1 ? '' : basename.slice(dotIndex)
+}
+
+function* walk(dir) {
+  if (!existsSync(dir)) return
+
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = join(dir, entry.name)
+    const relativePath = relative(repoRoot, fullPath)
+
+    if (entry.isDirectory()) {
+      if (!ignoredDirs.has(relativePath) && !ignoredDirs.has(entry.name)) {
+        yield* walk(fullPath)
+      }
+      continue
+    }
+
+    if (entry.isFile() && textExtensions.has(extensionOf(fullPath))) {
+      yield fullPath
+    }
+  }
+}
+
+const failures = []
+for (const root of checkedRoots) {
+  for (const filePath of walk(join(repoRoot, root))) {
+    const content = readFileSync(filePath, 'utf8')
+    const relativePath = relative(repoRoot, filePath)
+
+    for (const forbidden of [recipient, directProviderPath]) {
+      if (content.includes(forbidden)) {
+        failures.push(`${relativePath}: contains ${forbidden}`)
+      }
+    }
+  }
+}
+
+const contactForm = readFileSync(join(repoRoot, 'src/components/ContactForm.tsx'), 'utf8')
+const contactPage = readFileSync(join(repoRoot, 'src/app/contact/page.tsx'), 'utf8')
+const thanksPage = readFileSync(join(repoRoot, 'src/app/contact/thanks/page.tsx'), 'utf8')
+
+if (!contactForm.includes('fetch(contactEndpoint')) {
+  failures.push('ContactForm does not submit through the AJAX endpoint fetch path')
+}
+
+if (!contactForm.includes("role=\"alert\"")) {
+  failures.push('ContactForm does not expose an accessible visible failure alert')
+}
+
+if (!contactPage.includes('<ContactForm />')) {
+  failures.push('Contact page is not using the client ContactForm component')
+}
+
+if (thanksPage.includes(recipient)) {
+  failures.push('Thank-you page still exposes the destination mailbox')
+}
+
+const buildStaticDir = join(repoRoot, '.next/static')
+if (existsSync(buildStaticDir) && statSync(buildStaticDir).isDirectory()) {
+  console.log('Checked built static output for contact recipient leaks.')
+} else {
+  console.log('Build output not present; checked source and docs only.')
+}
+
+if (failures.length > 0) {
+  console.error(failures.join('\n'))
+  process.exit(1)
+}
+
+console.log('Contact form privacy checks passed.')

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,11 +1,9 @@
+import { ContactForm } from '@/components/ContactForm'
+
 const contactInfo = [
   { label: 'Address', value: '1174 Whitney Avenue\nHamden, CT 06517-3432', icon: '📍' },
   { label: 'Response times', value: 'We usually reply within 1 to 2 business days.', icon: '⏱️' },
 ]
-
-const formAction = 'https://formsubmit.co/hello@lexyalgo.com'
-const contactPageUrl = 'https://lexyalgo.com/contact'
-const thankYouUrl = 'https://lexyalgo.com/contact/thanks'
 
 export default function ContactPage() {
   return (
@@ -40,88 +38,7 @@ export default function ContactPage() {
           </div>
 
           <div className="lg:col-span-2">
-            <form
-              action={formAction}
-              method="POST"
-              className="bg-white rounded-2xl border border-slate-200 p-8 sm:p-10 space-y-6"
-            >
-              <div className="rounded-2xl border border-teal/20 bg-teal/5 p-5">
-                <p className="text-sm font-semibold text-slate-900">Send us a message</p>
-                <p className="mt-2 text-sm text-slate-700">
-                  Use the form below for product questions, feedback, partnerships, or press inquiries. Please do not include confidential case details here.
-                </p>
-              </div>
-
-              <input type="hidden" name="_subject" value="New LexyAlgo contact form submission" />
-              <input type="hidden" name="_next" value={thankYouUrl} />
-              <input type="hidden" name="_url" value={contactPageUrl} />
-              <input type="hidden" name="_template" value="table" />
-              <input type="text" name="_honey" className="hidden" tabIndex={-1} autoComplete="off" />
-
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
-                <div>
-                  <label htmlFor="name" className="block text-sm font-medium text-slate-700 mb-2">Name</label>
-                  <input
-                    id="name"
-                    name="name"
-                    type="text"
-                    placeholder="Your name"
-                    className="w-full px-4 py-3 rounded-xl border border-slate-200 text-sm focus:outline-none focus:ring-2 focus:ring-teal/20 focus:border-teal"
-                    required
-                  />
-                </div>
-                <div>
-                  <label htmlFor="email" className="block text-sm font-medium text-slate-700 mb-2">Email</label>
-                  <input
-                    id="email"
-                    name="email"
-                    type="email"
-                    placeholder="you@email.com"
-                    className="w-full px-4 py-3 rounded-xl border border-slate-200 text-sm focus:outline-none focus:ring-2 focus:ring-teal/20 focus:border-teal"
-                    required
-                  />
-                </div>
-              </div>
-
-              <div>
-                <label htmlFor="subject" className="block text-sm font-medium text-slate-700 mb-2">Subject</label>
-                <select
-                  id="subject"
-                  name="topic"
-                  className="w-full px-4 py-3 rounded-xl border border-slate-200 text-sm focus:outline-none focus:ring-2 focus:ring-teal/20 focus:border-teal text-slate-700"
-                  defaultValue="General inquiry"
-                >
-                  <option>General inquiry</option>
-                  <option>Calculator question</option>
-                  <option>Product feedback</option>
-                  <option>Partnership / integration</option>
-                  <option>Press / media</option>
-                  <option>Other</option>
-                </select>
-              </div>
-
-              <div>
-                <label htmlFor="message" className="block text-sm font-medium text-slate-700 mb-2">Message</label>
-                <textarea
-                  id="message"
-                  name="message"
-                  rows={6}
-                  placeholder="How can we help?"
-                  className="w-full px-4 py-3 rounded-xl border border-slate-200 text-sm focus:outline-none focus:ring-2 focus:ring-teal/20 focus:border-teal resize-none"
-                  required
-                />
-              </div>
-
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                <button
-                  type="submit"
-                  className="inline-flex items-center justify-center rounded-xl bg-teal px-8 py-3 font-semibold text-white shadow-sm shadow-teal/20 transition-all hover:bg-[#12434D] active:scale-[0.98]"
-                >
-                  Send message
-                </button>
-                <p className="text-sm text-slate-500">We usually reply within 1 to 2 business days.</p>
-              </div>
-            </form>
+            <ContactForm />
           </div>
         </div>
       </section>

--- a/src/app/contact/thanks/page.tsx
+++ b/src/app/contact/thanks/page.tsx
@@ -12,7 +12,7 @@ export default function ContactThanksPage() {
           A LexyAlgo team member should reply within one business day.
         </p>
         <p className="mt-3 text-sm text-slate-500">
-          If you do not hear back, email hello@lexyalgo.com directly.
+          Please use the contact form again if you need to send additional context.
         </p>
         <div className="mt-8">
           <a

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,0 +1,160 @@
+'use client'
+
+import type { FormEvent } from 'react'
+import { useState } from 'react'
+
+type SubmitStatus = 'idle' | 'submitting' | 'error'
+
+const contactRecipient = String.fromCharCode(
+  104,
+  101,
+  108,
+  108,
+  111,
+  64,
+  108,
+  101,
+  120,
+  121,
+  97,
+  108,
+  103,
+  111,
+  46,
+  99,
+  111,
+  109,
+)
+
+const contactEndpoint = `https://formsubmit.co/ajax/${contactRecipient}`
+const contactPageUrl = 'https://lexyalgo.com/contact'
+const thankYouUrl = '/contact/thanks'
+
+export function ContactForm() {
+  const [status, setStatus] = useState<SubmitStatus>('idle')
+  const [errorMessage, setErrorMessage] = useState('')
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setStatus('submitting')
+    setErrorMessage('')
+
+    const form = event.currentTarget
+    const formData = new FormData(form)
+    formData.set('_subject', 'New LexyAlgo contact form submission')
+    formData.set('_url', contactPageUrl)
+    formData.set('_template', 'table')
+
+    try {
+      const response = await fetch(contactEndpoint, {
+        method: 'POST',
+        headers: { Accept: 'application/json' },
+        body: formData,
+      })
+
+      if (!response.ok) {
+        throw new Error(`Contact form returned HTTP ${response.status}`)
+      }
+
+      const payload = (await response.json().catch(() => null)) as { success?: string; message?: string } | null
+      const providerMessage = `${payload?.success ?? ''} ${payload?.message ?? ''}`.toLowerCase()
+
+      if (providerMessage.includes('activation')) {
+        throw new Error('Contact delivery provider still requires mailbox activation.')
+      }
+
+      window.location.assign(thankYouUrl)
+    } catch (error) {
+      console.warn('Contact form submission failed:', error)
+      setStatus('error')
+      setErrorMessage('We could not send the message yet. Please try again in a few minutes.')
+    }
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="bg-white rounded-2xl border border-slate-200 p-8 sm:p-10 space-y-6"
+    >
+      <div className="rounded-2xl border border-teal/20 bg-teal/5 p-5">
+        <p className="text-sm font-semibold text-slate-900">Send us a message</p>
+        <p className="mt-2 text-sm text-slate-700">
+          Use the form below for product questions, feedback, partnerships, or press inquiries. Please do not include confidential case details here.
+        </p>
+      </div>
+
+      <input type="text" name="_honey" className="hidden" tabIndex={-1} autoComplete="off" />
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+        <div>
+          <label htmlFor="name" className="block text-sm font-medium text-slate-700 mb-2">Name</label>
+          <input
+            id="name"
+            name="name"
+            type="text"
+            placeholder="Your name"
+            className="w-full px-4 py-3 rounded-xl border border-slate-200 text-sm focus:outline-none focus:ring-2 focus:ring-teal/20 focus:border-teal"
+            required
+          />
+        </div>
+        <div>
+          <label htmlFor="email" className="block text-sm font-medium text-slate-700 mb-2">Email</label>
+          <input
+            id="email"
+            name="email"
+            type="email"
+            placeholder="you@email.com"
+            className="w-full px-4 py-3 rounded-xl border border-slate-200 text-sm focus:outline-none focus:ring-2 focus:ring-teal/20 focus:border-teal"
+            required
+          />
+        </div>
+      </div>
+
+      <div>
+        <label htmlFor="subject" className="block text-sm font-medium text-slate-700 mb-2">Subject</label>
+        <select
+          id="subject"
+          name="topic"
+          className="w-full px-4 py-3 rounded-xl border border-slate-200 text-sm focus:outline-none focus:ring-2 focus:ring-teal/20 focus:border-teal text-slate-700"
+          defaultValue="General inquiry"
+        >
+          <option>General inquiry</option>
+          <option>Calculator question</option>
+          <option>Product feedback</option>
+          <option>Partnership / integration</option>
+          <option>Press / media</option>
+          <option>Other</option>
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="message" className="block text-sm font-medium text-slate-700 mb-2">Message</label>
+        <textarea
+          id="message"
+          name="message"
+          rows={6}
+          placeholder="How can we help?"
+          className="w-full px-4 py-3 rounded-xl border border-slate-200 text-sm focus:outline-none focus:ring-2 focus:ring-teal/20 focus:border-teal resize-none"
+          required
+        />
+      </div>
+
+      {status === 'error' && (
+        <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" role="alert">
+          {errorMessage}
+        </div>
+      )}
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <button
+          type="submit"
+          disabled={status === 'submitting'}
+          className="inline-flex items-center justify-center rounded-xl bg-teal px-8 py-3 font-semibold text-white shadow-sm shadow-teal/20 transition-all hover:bg-[#12434D] active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {status === 'submitting' ? 'Sending…' : 'Send message'}
+        </button>
+        <p className="text-sm text-slate-500">We usually reply within 1 to 2 business days.</p>
+      </div>
+    </form>
+  )
+}


### PR DESCRIPTION
## Summary
- Rebuilds only the contact-form privacy/delivery-state slice from stale PR #76 on top of current `main`.
- Moves `/contact` submission into a client component using the FormSubmit AJAX path so the static form HTML/source no longer exposes the destination mailbox in an action URL.
- Adds visible failure handling for provider activation/non-OK responses and keeps success on `/contact/thanks`.
- Adds `npm run test:contact-form` to guard against raw recipient leakage in source/built output and updates deployment contact verification docs.

## Scope guard
PR #76 is superseded here only for the contact-form slice. Its Asset Divider gate/copy changes are intentionally left out because Asset Divider is now publicly launched at `calc.lexyalgo.com`; this PR preserves the current Launch/Open Asset Divider CTA posture from `main`.

## Verification
- `gh pr list -R peacockesq/lexyalgo-site --state open` showed PR #76 still open and this branch was rebuilt from current `origin/main`, not by mutating #76.
- `npm run lint` ✅
- `npm run test:contact-form` before and after build ✅
- `npm run build` ✅
- Raw source/build search for `hello@lexyalgo.com`, `formsubmit.co/hello`, and `formsubmit.co/ajax/hello` returned no matches ✅
- Local browser QA on `http://127.0.0.1:3100/contact` ✅
  - desktop success path: required-field validation engaged, mocked POST submitted, redirected to `/contact/thanks`, no console/page errors
  - mobile activation-failure path: required-field validation engaged, mocked POST submitted, visible failure alert stayed on `/contact`, no console/page errors
  - rendered `/contact` source had no raw recipient leak and no static form `action`

## Deployment
No deployment from this card.

Refs #81, #24, #76.
