### PR TITLE
chore: capture LexyAlgo static runtime as code

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,30 @@
+# Dependency and package-manager caches
+node_modules
+.npm
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Next.js / Tina / build output
+.next
+out
+.tina
+.vercel
+.turbo
+coverage
+
+# Local/editor/system files
+.git
+.gitignore
+.github
+.DS_Store
+.env
+.env.*
+*.local
+*.log
+
+# Hermes/Kanban scratch artifacts; never bake worker evidence into runtime images
+evidence
+PR_TAIL_AUDIT.md
+remote_inventory.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+# syntax=docker/dockerfile:1.7
+
+FROM node:22-alpine AS builder
+
+ENV NEXT_TELEMETRY_DISABLED=1
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+COPY scripts/patch-tinacms-vite-define.mjs ./scripts/patch-tinacms-vite-define.mjs
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+FROM nginx:stable-alpine AS runner
+
+LABEL org.opencontainers.image.title="LexyAlgo static site"
+LABEL org.opencontainers.image.description="Static Next.js export served by nginx for lexyalgo.com."
+
+COPY --from=builder /app/out /usr/share/nginx/html
+COPY <<'NGINX' /etc/nginx/conf.d/default.conf
+server {
+    listen 3000;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location = /healthz {
+        access_log off;
+        add_header Content-Type text/plain;
+        return 200 'ok';
+    }
+
+    location / {
+        try_files $uri $uri.html $uri/index.html =404;
+    }
+
+    error_page 404 /404.html;
+}
+NGINX
+
+EXPOSE 3000
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:3000/ >/dev/null 2>&1 || exit 1

--- a/docker-compose.hetzner.yml
+++ b/docker-compose.hetzner.yml
@@ -1,0 +1,21 @@
+services:
+  site:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: runner
+    image: ${LEXYALGO_SITE_IMAGE:-lexyalgo-site:local}
+    container_name: ${LEXYALGO_SITE_CONTAINER:-lexyalgo-site}
+    restart: unless-stopped
+    networks:
+      - coolify
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3000/ >/dev/null 2>&1 || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+
+networks:
+  coolify:
+    external: true

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,13 +2,13 @@
 
 ## Current hosting shape
 
-Known production proof from issue tracking and live Hostinger inspection:
+Known production/staging proof from the 2026-06-18 read-only runtime inventory:
 
-- `lexyalgo.com` and `staging.lexyalgo.com` are fronted by Traefik on a Hostinger-hosted server.
-- Production currently routes to container `lexyalgo-site` on port `3000`.
-- Staging currently routes to container `lexyalgo-site-staging` on port `3000`.
-- The site is a static Next.js export.
-- This repository is the source of truth for the build and now also carries the deploy workflow for Hostinger.
+- `lexyalgo.com` and `www.lexyalgo.com` resolve to the existing `srv801553` / `lexyvps` host (`82.25.93.50`) and serve container `lexyalgo-site` on port `3000` through the existing `coolify`/Traefik proxy path.
+- `staging.lexyalgo.com` resolves to the existing Hetzner host `lexy-hetzner-01` (`37.27.49.209`) and serves container `lexyalgo-site-staging` on port `3000` through the existing proxy path.
+- The site is a static Next.js export served by nginx from `/usr/share/nginx/html` inside the container.
+- `Dockerfile` and `docker-compose.hetzner.yml` now capture the static-container runtime shape without adding new networks, volumes, secrets, databases, or proxy labels.
+- See [`docs/hetzner-runtime-inventory-2026-06-18.md`](./hetzner-runtime-inventory-2026-06-18.md) for the read-only DNS/container evidence and PR #78 drift notes.
 
 ## Build artifact
 
@@ -92,7 +92,7 @@ Current known live Lexy targets:
 - production container: `lexyalgo-site`
 - production container path: `/usr/share/nginx/html`
 - staging container: `lexyalgo-site-staging`
-- staging container path: `/app/out`
+- staging container path: `/usr/share/nginx/html`
 
 ### Plain host-path deploy
 

--- a/docs/hetzner-runtime-inventory-2026-06-18.md
+++ b/docs/hetzner-runtime-inventory-2026-06-18.md
@@ -1,0 +1,82 @@
+# LexyAlgo static runtime inventory — 2026-06-18
+
+This inventory was captured read-only before rebuilding the runtime-as-code slice from stale PR #78. No deployment, DNS change, container restart, or new infrastructure was performed.
+
+## Scope and source
+
+- Repository: `peacockesq/lexyalgo-site`
+- Current main at inventory start: `5060c378ff34555323029a45cdcda1a1290235cc`
+- Stale source PR: #78, branch `deploy/hetzner-runtime`
+- PR #78 status at capture: still open and untouched; its diff contains 2,292 files, including 2,272 `content/corpus/*` files. This replacement keeps only the runtime/runbook slice and excludes that corpus dump.
+
+## Public DNS and HTTP state
+
+Captured from the worker host on 2026-06-18 UTC:
+
+| Host | A record observed | HTTP proof | Server header | Notes |
+| --- | --- | --- | --- | --- |
+| `lexyalgo.com` | `82.25.93.50` | `200` | `nginx/1.31.1` | Production is currently on the existing `srv801553`/`lexyvps` host, not the Hetzner staging host. |
+| `www.lexyalgo.com` | `82.25.93.50` | `200` | `nginx/1.31.1` | Same production origin and static artifact as apex. |
+| `staging.lexyalgo.com` | `37.27.49.209` | `200` | `Caddy`, `nginx/1.31.0` | Existing Hetzner host `lexy-hetzner-01`; no DNS or proxy changes made here. |
+
+## Runtime/container state
+
+### Production (`srv801553` / `lexyvps`, `82.25.93.50`)
+
+- Public hosts: `lexyalgo.com`, `www.lexyalgo.com`
+- Container: `lexyalgo-site`
+- Image name observed: `lexyalgo-site:latest`
+- Restart policy: `unless-stopped`
+- Docker network: `coolify`
+- Container has no mounts; it serves baked static files from `/usr/share/nginx/html`.
+- Internal readiness probe: `http://127.0.0.1:3000/` returned `200 OK` from nginx.
+- Public reverse proxy: `coolify-proxy` / Traefik is running on the host and terminates public 80/443.
+
+### Staging (`lexy-hetzner-01`, `37.27.49.209`)
+
+- Public host: `staging.lexyalgo.com`
+- Container observed: `lexyalgo-site-staging`
+- Image name observed: `lexyalgo-site-staging-site:plan-profile-61d1b14a`
+- Restart policy: `unless-stopped`
+- Docker network: `coolify`
+- Container has no mounts; it serves baked static files from `/usr/share/nginx/html`.
+- Internal readiness probe: `http://127.0.0.1:3000/` returned `200 OK` from nginx.
+- Public response includes both Caddy and nginx headers.
+
+### Hetzner repo/runtime drift
+
+The Hetzner `/opt/lexyalgo-site` checkout is on stale branch `deploy/hetzner-runtime` at `8a1fd1e4d8792c89a86c6a2d0b98e9a770fd2362` and has many dirty `content/corpus/cases/*.json` files. That branch is the source of the old PR #78 bloat and should not be merged as-is.
+
+## Runtime-as-code represented in this repository
+
+This branch adds:
+
+- `Dockerfile`: builds the static Next.js export with Node 22, then serves `out/` with nginx on port `3000`.
+- `docker-compose.hetzner.yml`: one-service compose runtime for the existing `coolify` external Docker network, with configurable image/container names.
+- `scripts/verify-static-runtime.mjs`: read-only DNS/HTTP smoke verifier for production, www, staging, and `/products/asset-divider`.
+- `.dockerignore`: keeps local caches, Git data, environment files, and worker evidence out of Docker contexts.
+
+The compose file intentionally does not declare proxy labels, new networks, volumes, databases, or secrets. It mirrors the existing static-container shape and expects the already-existing Coolify/Traefik/Caddy routing layer to point at the container on port `3000`.
+
+## Safe verification commands
+
+Local/non-deploying checks:
+
+```bash
+npm ci
+npm run lint
+npm run build
+docker compose -f docker-compose.hetzner.yml config
+LEXYALGO_SITE_CONTAINER=lexyalgo-site-runtime-check \
+  LEXYALGO_SITE_IMAGE=lexyalgo-site:runtime-check \
+  docker compose -f docker-compose.hetzner.yml build site
+npm run verify:runtime
+```
+
+Do not run `docker compose up` against production/staging from a development workstation. Deployment remains controlled by the existing GitHub Actions/static export path or an explicitly approved operator runbook.
+
+## Deployment guardrails
+
+- No deployment is authorized by this card.
+- Do not close PR #78 until the replacement PR lands and Willie explicitly approves that disposition.
+- Browser QA before any deployment approval must cover desktop and mobile smoke for `/` and `/products/asset-divider` on the staged candidate.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "start": "next start",
     "lint": "tsc --noEmit -p tsconfig.lint.json",
     "test:contact-form": "node scripts/check-contact-form-privacy.mjs",
+    "verify:runtime": "node scripts/verify-static-runtime.mjs",
     "verify:shared-auth-links": "node scripts/verify-shared-auth-links.mjs",
     "postinstall": "node scripts/patch-tinacms-vite-define.mjs"
   },

--- a/scripts/verify-static-runtime.mjs
+++ b/scripts/verify-static-runtime.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+import dns from "node:dns/promises";
+
+const DEFAULT_URLS = [
+  "https://lexyalgo.com/",
+  "https://www.lexyalgo.com/",
+  "https://staging.lexyalgo.com/",
+  "https://lexyalgo.com/products/asset-divider",
+  "https://staging.lexyalgo.com/products/asset-divider",
+];
+
+const urls = (process.env.LEXYALGO_RUNTIME_URLS || process.argv.slice(2).join(",") || DEFAULT_URLS.join(","))
+  .split(",")
+  .map((value) => value.trim())
+  .filter(Boolean);
+
+const expectedTextByPath = new Map([
+  ["/", ["LexyAlgo", "Divorce Tools"]],
+  ["/products/asset-divider", ["Asset Divider"]],
+]);
+
+async function resolveHost(hostname) {
+  try {
+    const records = await dns.lookup(hostname, { all: true, family: 4 });
+    return records.map((record) => record.address).sort();
+  } catch (error) {
+    return [`DNS_ERROR:${error.message}`];
+  }
+}
+
+async function verifyUrl(rawUrl) {
+  const url = new URL(rawUrl);
+  const addresses = await resolveHost(url.hostname);
+  const response = await fetch(url, { redirect: "manual" });
+  const body = await response.text();
+  const requiredText = expectedTextByPath.get(url.pathname.endsWith("/") && url.pathname !== "/" ? url.pathname.slice(0, -1) : url.pathname) || ["LexyAlgo"];
+  const missingText = requiredText.filter((needle) => !body.includes(needle));
+
+  return {
+    url: url.toString(),
+    dnsA: addresses,
+    status: response.status,
+    server: response.headers.get("server") || "",
+    contentLength: Number(response.headers.get("content-length") || body.length),
+    requiredText,
+    missingText,
+    ok: response.status === 200 && missingText.length === 0,
+  };
+}
+
+const results = [];
+let failed = false;
+
+for (const url of urls) {
+  try {
+    const result = await verifyUrl(url);
+    results.push(result);
+    if (!result.ok) failed = true;
+  } catch (error) {
+    failed = true;
+    results.push({ url, ok: false, error: error instanceof Error ? error.message : String(error) });
+  }
+}
+
+console.log(JSON.stringify({ checkedAt: new Date().toISOString(), results }, null, 2));
+
+if (failed) {
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary

Rebuilds the useful static-container runtime slice from stale PR #78 as a narrow current-main operations PR, without merging the 2,272-file corpus dump.

Adds:

- `Dockerfile` using Node 22 builder + nginx static runtime on port 3000
- `docker-compose.hetzner.yml` for the existing `coolify` external network and static site container shape
- `.dockerignore` to keep local caches/env/evidence out of runtime builds
- `scripts/verify-static-runtime.mjs` and `npm run verify:runtime` for read-only DNS/HTTP smoke checks
- `docs/hetzner-runtime-inventory-2026-06-18.md` with read-only production/staging runtime evidence and PR #78 drift notes
- Deployment runbook corrections for current production/staging routing reality

No deployment, DNS change, proxy change, container restart, new infrastructure, or PR #78 mutation was performed.

Fixes #83.

## Runtime inventory highlights

- `lexyalgo.com` and `www.lexyalgo.com` currently resolve to `82.25.93.50` and serve HTTP 200 via nginx.
- `staging.lexyalgo.com` currently resolves to `37.27.49.209` and serves HTTP 200 via Caddy/nginx.
- Production container observed: `lexyalgo-site`, static nginx serving `/usr/share/nginx/html`, existing `coolify` network.
- Staging container observed: `lexyalgo-site-staging`, static nginx serving `/usr/share/nginx/html`, existing `coolify` network.
- Hetzner `/opt/lexyalgo-site` is still on stale `deploy/hetzner-runtime` with dirty corpus files; this PR does not import them.

## Verification

- `gh pr list -R peacockesq/lexyalgo-site --state open --json number,title,baseRefName,headRefName,mergeStateStatus,reviewDecision,updatedAt,url,statusCheckRollup` captured before implementation; PR #78 remains open/untouched.
- PR #78 local diff audit: 2,292 files, including 2,272 `content/corpus/*` files.
- `npm ci` completed with existing peer warnings and existing audit findings.
- `npm run lint` passed.
- `npm run build` passed; Next generated 72 static pages.
- `npm run verify:runtime` passed for `lexyalgo.com`, `www.lexyalgo.com`, `staging.lexyalgo.com`, and `/products/asset-divider` on prod/staging.
- Local machine had no Docker CLI, so Docker validation ran on existing Hetzner Docker host in a temporary non-deploy directory:
  - `docker compose -f docker-compose.hetzner.yml config` passed.
  - `docker build -t lexyalgo-site:runtime-as-code-check-t4935 .` passed.
  - Temporary context and image were removed after validation.
- `git diff --cached --check` passed before commit.

## Notes / follow-up gates

- `npm audit --omit=dev` still reports pre-existing dependency advisories, including Next/Tina transitive findings. This branch does not change dependencies and the Docker runtime image serves static files from nginx only, but dependency remediation should be tracked separately before any future production-risk deploy decision.
- Browser QA is still required before any deployment approval: desktop and mobile smoke for `/` and `/products/asset-divider` on the actual staged candidate.
- Do not close stale PR #78 until this replacement PR lands and Willie approves that disposition.
