### PR TITLE
Cut QDRO CTAs over to V2 runtime

### DIFF
--- a/scripts/verify-shared-auth-links.mjs
+++ b/scripts/verify-shared-auth-links.mjs
@@ -12,8 +12,12 @@ const EXPECTED_ATLAS_LOGIN_PATH = "/login";
 const EXPECTED_CALLBACKS = {
   divorceAlpha: "https://app.lexyalgo.com",
   estatePlanning: "https://doc.lexyalgo.com/interview?i=docassemble.LexyAlgo:data/questions/estate_planning.yml",
-  qdro: "https://doc.lexyalgo.com/interview?i=docassemble.LexyAlgo:data/questions/qdro_router.yml",
+  qdro: "https://doc-v2.lexyalgo.com/interview?i=docassemble.LexyAlgoQDROV2:data/questions/qdro_v2_router.yml",
 };
+const FORBIDDEN_QDRO_CALLBACKS = [
+  "https://doc.lexyalgo.com/interview?i=docassemble.LexyAlgo:data/questions/qdro_router.yml",
+  "docassemble.LexyAlgo:data/questions/qdro_router.yml",
+];
 const PRODUCT_PAGES = {
   divorceAlpha: "src/app/products/divorce/page.tsx",
   estatePlanning: "src/app/products/estate-planning/page.tsx",
@@ -64,6 +68,23 @@ function literalValue(source, expression) {
   }
 
   const interviewKey = interviewMatch[1];
+  const interviewDirectPattern = new RegExp(`${interviewKey}:\\s*([A-Z0-9_]+)`);
+  const interviewDirectMatch = source.match(interviewDirectPattern);
+  if (interviewDirectMatch) {
+    const constName = interviewDirectMatch[1];
+    const constMatch = source.match(new RegExp(`const\\s+${constName}\\s*=\\s*['\"]([^'\"]+)['\"]`));
+    if (!constMatch) {
+      fail(`Missing ${constName} constant for docassembleInterviews.${interviewKey}`);
+    }
+    return constMatch[1];
+  }
+
+  const literalInterviewPattern = new RegExp(`${interviewKey}:\\s*['\"]([^'\"]+)['\"]`);
+  const literalInterviewMatch = source.match(literalInterviewPattern);
+  if (literalInterviewMatch) {
+    return literalInterviewMatch[1];
+  }
+
   const interviewPattern = new RegExp(`${interviewKey}:\\s*` + "`\\$\\{DOCASSEMBLE_ORIGIN\\}([^`]+)`");
   const interviewValueMatch = source.match(interviewPattern);
   if (!interviewValueMatch) {
@@ -86,6 +107,17 @@ async function assertProductPageUsesSharedLink(key, pagePath) {
   if (!source.includes(`sharedAuthLinks.${member}`)) {
     fail(`${pagePath} must use sharedAuthLinks.${member}`);
   }
+
+  if (key === "qdro") {
+    if (source.includes("doc.lexyalgo.com")) {
+      fail(`${pagePath} must not advertise the legacy Docassemble host in visible copy`);
+    }
+    for (const forbiddenCallback of FORBIDDEN_QDRO_CALLBACKS) {
+      if (source.includes(forbiddenCallback)) {
+        fail(`${pagePath} must not contain the legacy QDRO V1 callback`, { forbiddenCallback });
+      }
+    }
+  }
 }
 
 async function verifyLivePages(baseUrl) {
@@ -104,7 +136,16 @@ async function verifyLivePages(baseUrl) {
     qdro: "/products/qdro",
   };
 
-  for (const [key, pathname] of Object.entries(livePaths)) {
+  const requestedLiveKeys = (process.env.LEXYSITE_CHECK_PRODUCTS || Object.keys(livePaths).join(","))
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  for (const key of requestedLiveKeys) {
+    const pathname = livePaths[key];
+    if (!pathname) {
+      fail(`Unknown live product key`, { key, allowed: Object.keys(livePaths) });
+    }
     const response = await fetch(new URL(pathname, baseUrl), {
       headers: { "user-agent": "lexyalgo-shared-auth-link-check/1.0" },
     });
@@ -128,6 +169,11 @@ async function verifyLivePages(baseUrl) {
 
 async function main() {
   const source = await readFile(sharedAuthPath, "utf8");
+  for (const forbiddenCallback of FORBIDDEN_QDRO_CALLBACKS) {
+    if (source.includes(forbiddenCallback)) {
+      fail(`Shared auth source must not contain the legacy QDRO V1 callback`, { forbiddenCallback });
+    }
+  }
 
   for (const [key, expectedCallback] of Object.entries(EXPECTED_CALLBACKS)) {
     const expression = extractHrefFromLine(source, key);

--- a/src/app/products/qdro/page.tsx
+++ b/src/app/products/qdro/page.tsx
@@ -52,11 +52,11 @@ export default function QdroPage() {
           <div className="rounded-2xl bg-[#F5EDE5] border border-[#8B5E3C]/15 p-8 text-center">
             <p className="text-sm font-semibold text-[#8B5E3C] uppercase tracking-wider mb-2">Available now</p>
             <p className="text-slate-700 leading-relaxed">
-              The QDRO generator is live at{' '}
+              The QDRO V2 generator is available through our secure LexyAlgo launch flow.{' '}
               <a href={QDRO_URL} className="font-semibold text-[#8B5E3C] underline underline-offset-2 hover:text-[#6F4A2E]">
-                doc.lexyalgo.com
+                Start your order
               </a>
-              . Start your order there.
+              .
             </p>
           </div>
         </div>

--- a/src/lib/shared-auth-links.ts
+++ b/src/lib/shared-auth-links.ts
@@ -1,10 +1,11 @@
 const ATLAS_LOGIN_URL = 'https://atlas.lexyalgo.com/login'
 const DOCASSEMBLE_ORIGIN = 'https://doc.lexyalgo.com'
+const QDRO_V2_INTERVIEW_URL = 'https://doc-v2.lexyalgo.com/interview?i=docassemble.LexyAlgoQDROV2:data/questions/qdro_v2_router.yml'
 
 export const docassembleInterviews = {
   divorce: `${DOCASSEMBLE_ORIGIN}/interview?i=docassemble.LexyAlgo:data/questions/ct_divorce.yml`,
   estatePlanning: `${DOCASSEMBLE_ORIGIN}/interview?i=docassemble.LexyAlgo:data/questions/estate_planning.yml`,
-  qdro: `${DOCASSEMBLE_ORIGIN}/interview?i=docassemble.LexyAlgo:data/questions/qdro_router.yml`,
+  qdro: QDRO_V2_INTERVIEW_URL,
 } as const
 
 export function atlasLoginUrl(callbackUrl: string): string {


### PR DESCRIPTION
## Summary
- Routes the public QDRO product CTAs through Atlas to the approved QDRO V2 runtime.
- Removes visible copy that advertised the legacy `doc.lexyalgo.com` host as the QDRO launch path.
- Tightens `verify:shared-auth-links` so the QDRO callback must use `doc-v2.lexyalgo.com` / `docassemble.LexyAlgoQDROV2:data/questions/qdro_v2_router.yml` and fails if the legacy QDRO V1 callback returns.

## Before / after CTA URL
Before:
`https://atlas.lexyalgo.com/login?callbackUrl=https%3A%2F%2Fdoc.lexyalgo.com%2Finterview%3Fi%3Ddocassemble.LexyAlgo%3Adata%2Fquestions%2Fqdro_router.yml`

After:
`https://atlas.lexyalgo.com/login?callbackUrl=https%3A%2F%2Fdoc-v2.lexyalgo.com%2Finterview%3Fi%3Ddocassemble.LexyAlgoQDROV2%3Adata%2Fquestions%2Fqdro_v2_router.yml`

QDRO V2 final launch proof: Kanban `t_cc434cf8`, deployed main `8b79f85`.

## Verification
- `npm ci` (refreshed WSL/Linux native node_modules after build found Darwin esbuild binary)
- `npm run verify:shared-auth-links` ✅
- `npm run lint` ✅
- `npm run build` ✅
- Static generated route assertion against `out/products/qdro.html` confirmed all QDRO CTA hrefs contain `doc-v2.lexyalgo.com` and `docassemble.LexyAlgoQDROV2:data/questions/qdro_v2_router.yml`, and do not contain the legacy `docassemble.LexyAlgo:data/questions/qdro_router.yml` callback ✅
- Atlas callback retention smoke: `curl -sSL` of the new Atlas login URL returned HTTP 200 with final URL retaining the full `doc-v2` callback ✅
- `git diff --check` ✅

## Notes
No deploy/merge in this PR. Needs Otto review plus headed desktop/mobile browser QA before merge/deploy.

Closes #87
Kanban: `t_fc20c37b`
