### PR TITLE
fix: repair public /qdro alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "verify:runtime": "node scripts/verify-static-runtime.mjs",
     "verify:favicon": "node scripts/verify-favicon-static.mjs",
     "verify:shared-auth-links": "node scripts/verify-shared-auth-links.mjs",
+    "verify:qdro-route": "node scripts/verify-qdro-public-route.mjs",
     "postinstall": "node scripts/patch-tinacms-vite-define.mjs"
   },
   "keywords": [],

--- a/scripts/verify-qdro-public-route.mjs
+++ b/scripts/verify-qdro-public-route.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+
+import { readFile, stat } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const expectedCanonical = 'https://www.lexyalgo.com/products/qdro'
+const expectedCallback = 'https://doc-v2.lexyalgo.com/interview?i=docassemble.LexyAlgoQDROV2:data/questions/qdro_v2_router.yml'
+const expectedAtlasHref = new URL('/login', 'https://atlas.lexyalgo.com')
+expectedAtlasHref.searchParams.set('callbackUrl', expectedCallback)
+
+function fail(message, details = {}) {
+  console.error(JSON.stringify({ ok: false, error: message, ...details }, null, 2))
+  process.exit(1)
+}
+
+async function readOutHtml(routePath) {
+  const htmlPath = path.join(repoRoot, 'out', `${routePath.replace(/^\//, '')}.html`)
+  try {
+    await stat(htmlPath)
+  } catch (error) {
+    fail('Missing exported route HTML. Run npm run build before this verifier.', {
+      routePath,
+      htmlPath,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+  return { htmlPath, html: await readFile(htmlPath, 'utf8') }
+}
+
+function assertIncludes(html, needle, label, htmlPath) {
+  if (!html.includes(needle)) {
+    fail(`Exported ${label} is missing expected content`, { htmlPath, needle })
+  }
+}
+
+const aliasSourcePath = path.join(repoRoot, 'src/app/qdro/page.tsx')
+const aliasSource = await readFile(aliasSourcePath, 'utf8')
+if (!aliasSource.includes("../products/qdro/page") || !aliasSource.includes('qdroMetadata')) {
+  fail('Public /qdro alias must reuse the canonical /products/qdro page and metadata', { aliasSourcePath })
+}
+
+const canonicalPageSource = await readFile(path.join(repoRoot, 'src/app/products/qdro/page.tsx'), 'utf8')
+if (!canonicalPageSource.includes(`canonical: '${expectedCanonical}'`)) {
+  fail('Canonical QDRO page metadata must publish the canonical /products/qdro URL', {
+    expectedCanonical,
+  })
+}
+
+const alias = await readOutHtml('/qdro')
+const canonical = await readOutHtml('/products/qdro')
+const encodedHref = expectedAtlasHref.toString().replaceAll('&', '&amp;')
+
+for (const [label, artifact] of Object.entries({ alias, canonical })) {
+  assertIncludes(artifact.html, 'Generate your QDRO', label, artifact.htmlPath)
+  assertIncludes(artifact.html, expectedCanonical, label, artifact.htmlPath)
+  if (!artifact.html.includes(expectedAtlasHref.toString()) && !artifact.html.includes(encodedHref)) {
+    fail(`Exported ${label} is missing approved Atlas -> QDRO V2 callback`, {
+      htmlPath: artifact.htmlPath,
+      expectedHref: expectedAtlasHref.toString(),
+    })
+  }
+}
+
+console.log(JSON.stringify({
+  ok: true,
+  checked: {
+    aliasRoute: '/qdro',
+    canonicalRoute: '/products/qdro',
+    canonical: expectedCanonical,
+    qdroCallback: expectedCallback,
+    files: [alias.htmlPath, canonical.htmlPath],
+  },
+}, null, 2))

--- a/src/app/products/qdro/page.tsx
+++ b/src/app/products/qdro/page.tsx
@@ -5,6 +5,9 @@ import { sharedAuthLinks } from '@/lib/shared-auth-links'
 export const metadata: Metadata = {
   title: 'QDRO Generator — LexyAlgo',
   description: 'Generate a Qualified Domestic Relations Order (QDRO) for retirement plan division in divorce. Starting at $100 per order. Supports nearly one million plans nationwide.',
+  alternates: {
+    canonical: 'https://www.lexyalgo.com/products/qdro',
+  },
 }
 
 const QDRO_URL = sharedAuthLinks.qdro

--- a/src/app/qdro/page.tsx
+++ b/src/app/qdro/page.tsx
@@ -1,0 +1,5 @@
+import QdroPage, { metadata as qdroMetadata } from '../products/qdro/page'
+
+export const metadata = qdroMetadata
+
+export default QdroPage


### PR DESCRIPTION
## Summary

Fixes #91.

Repairs the public `/qdro` acquisition/bookmark route after the QDRO V2 CTA cutover by adding a static-export App Router alias that reuses the canonical `/products/qdro` page and metadata. The canonical page now publishes `https://www.lexyalgo.com/products/qdro`, and the new verifier locks both `/qdro` and `/products/qdro` to the approved Atlas -> QDRO V2 callback.

Kanban: `t_bfe2d898`

## Changes

- Added `src/app/qdro/page.tsx` as a small alias to the canonical QDRO page.
- Added canonical metadata to `src/app/products/qdro/page.tsx`.
- Added `npm run verify:qdro-route` to assert exported `/qdro`, canonical `/products/qdro`, canonical link, and approved QDRO V2 callback.

## Proof

Live pre-fix production reconstruction:

```text
https://www.lexyalgo.com/qdro -> HTTP/2 404
https://www.lexyalgo.com/products/qdro -> HTTP/2 200
```

Commands run:

```text
npm run lint
npm run build
npm run verify:shared-auth-links
npm run verify:qdro-route
npm run verify:favicon
npm audit --omit=dev --audit-level=high
git diff --check
```

Verifier receipts:

```json
{
  "verify:shared-auth-links": {
    "ok": true,
    "checked": ["divorceAlpha", "estatePlanning", "qdro"],
    "liveBaseUrl": null
  },
  "verify:qdro-route": {
    "ok": true,
    "checked": {
      "aliasRoute": "/qdro",
      "canonicalRoute": "/products/qdro",
      "canonical": "https://www.lexyalgo.com/products/qdro",
      "qdroCallback": "https://doc-v2.lexyalgo.com/interview?i=docassemble.LexyAlgoQDROV2:data/questions/qdro_v2_router.yml",
      "files": ["out/qdro.html", "out/products/qdro.html"]
    }
  },
  "verify:favicon": {
    "ok": true,
    "checked": ["public/favicon.ico", "public/favicon.png", "out/favicon.ico"]
  }
}
```

Local static-export curl proof with extensionless route mapping:

```text
LOCAL /qdro
HTTP/1.0 200 OK
Content-type: text/html
Content-Length: 52718
{'path': '/qdro', 'bytes': 52682, 'missing': []}

LOCAL /products/qdro
HTTP/1.0 200 OK
Content-type: text/html
Content-Length: 53195
{'path': '/products/qdro', 'bytes': 53159, 'missing': []}
```

Audit note: `npm audit --omit=dev --audit-level=high` exited 0. Current report contains moderate advisories only; this PR does not change dependency versions or lockfiles.

Build note: Next still warns about multiple lockfiles under `/home/willie/openclaw-from-mac/workspace`; existing repo/workspace condition, not introduced here.
