### PR TITLE
Fix QDRO trailing-slash static routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "tinacms dev -c \"next dev\"",
     "build": "tinacms build --local --skip-cloud-checks && next build",
+    "postbuild": "node scripts/ensure-qdro-trailing-slash-routes.mjs",
     "start": "next start",
     "lint": "tsc --noEmit -p tsconfig.lint.json",
     "test:contact-form": "node scripts/check-contact-form-privacy.mjs",

--- a/scripts/ensure-qdro-trailing-slash-routes.mjs
+++ b/scripts/ensure-qdro-trailing-slash-routes.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+import { copyFile, mkdir, stat } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const qdroRoutes = ['qdro', 'products/qdro']
+
+function fail(message, details = {}) {
+  console.error(JSON.stringify({ ok: false, error: message, ...details }, null, 2))
+  process.exit(1)
+}
+
+for (const route of qdroRoutes) {
+  const source = path.join(repoRoot, 'out', `${route}.html`)
+  const destinationDir = path.join(repoRoot, 'out', route)
+  const destination = path.join(destinationDir, 'index.html')
+
+  try {
+    await stat(source)
+  } catch (error) {
+    fail('Missing source HTML for QDRO static trailing-slash route repair.', {
+      route,
+      source,
+      errorDetail: error instanceof Error ? error.message : String(error),
+    })
+  }
+
+  await mkdir(destinationDir, { recursive: true })
+  await copyFile(source, destination)
+}
+
+console.log(JSON.stringify({
+  ok: true,
+  repairedRoutes: qdroRoutes.map((route) => `/${route}/`),
+}, null, 2))

--- a/scripts/verify-qdro-public-route.mjs
+++ b/scripts/verify-qdro-public-route.mjs
@@ -16,14 +16,17 @@ function fail(message, details = {}) {
 }
 
 async function readOutHtml(routePath) {
-  const htmlPath = path.join(repoRoot, 'out', `${routePath.replace(/^\//, '')}.html`)
+  const normalizedRoute = routePath.replace(/^\//, '').replace(/\/$/, '')
+  const htmlPath = routePath.endsWith('/')
+    ? path.join(repoRoot, 'out', normalizedRoute, 'index.html')
+    : path.join(repoRoot, 'out', `${normalizedRoute}.html`)
   try {
     await stat(htmlPath)
   } catch (error) {
     fail('Missing exported route HTML. Run npm run build before this verifier.', {
       routePath,
       htmlPath,
-      error: error instanceof Error ? error.message : String(error),
+      errorDetail: error instanceof Error ? error.message : String(error),
     })
   }
   return { htmlPath, html: await readFile(htmlPath, 'utf8') }
@@ -48,11 +51,15 @@ if (!canonicalPageSource.includes(`canonical: '${expectedCanonical}'`)) {
   })
 }
 
-const alias = await readOutHtml('/qdro')
-const canonical = await readOutHtml('/products/qdro')
+const checkedRoutes = {
+  alias: await readOutHtml('/qdro'),
+  aliasTrailingSlash: await readOutHtml('/qdro/'),
+  canonical: await readOutHtml('/products/qdro'),
+  canonicalTrailingSlash: await readOutHtml('/products/qdro/'),
+}
 const encodedHref = expectedAtlasHref.toString().replaceAll('&', '&amp;')
 
-for (const [label, artifact] of Object.entries({ alias, canonical })) {
+for (const [label, artifact] of Object.entries(checkedRoutes)) {
   assertIncludes(artifact.html, 'Generate your QDRO', label, artifact.htmlPath)
   assertIncludes(artifact.html, expectedCanonical, label, artifact.htmlPath)
   if (!artifact.html.includes(expectedAtlasHref.toString()) && !artifact.html.includes(encodedHref)) {
@@ -66,10 +73,9 @@ for (const [label, artifact] of Object.entries({ alias, canonical })) {
 console.log(JSON.stringify({
   ok: true,
   checked: {
-    aliasRoute: '/qdro',
-    canonicalRoute: '/products/qdro',
+    routes: ['/qdro', '/qdro/', '/products/qdro', '/products/qdro/'],
     canonical: expectedCanonical,
     qdroCallback: expectedCallback,
-    files: [alias.htmlPath, canonical.htmlPath],
+    files: Object.values(checkedRoutes).map((artifact) => artifact.htmlPath),
   },
 }, null, 2))


### PR DESCRIPTION
## Summary
- Adds a post-build static export repair for the QDRO public routes so `/qdro/` and `/products/qdro/` get `index.html` artifacts alongside the existing clean URLs.
- Expands the QDRO route verifier to require all four route variants: `/qdro`, `/qdro/`, `/products/qdro`, and `/products/qdro/`.
- Keeps the approved Atlas login CTA callback pointed at the QDRO V2 router on `doc-v2.lexyalgo.com`.

Fixes #93.

## Pre-fix reproduction
Live before fix:
- `https://lexyalgo.com/qdro` -> 200, QDRO title
- `https://lexyalgo.com/qdro/` -> 404
- `https://www.lexyalgo.com/qdro` -> 200, QDRO title
- `https://www.lexyalgo.com/qdro/` -> 404
- `https://lexyalgo.com/products/qdro` -> 200, QDRO title
- `https://lexyalgo.com/products/qdro/` -> 404
- `https://www.lexyalgo.com/products/qdro` -> 200, QDRO title
- `https://www.lexyalgo.com/products/qdro/` -> 404

Verifier RED before repair:
- `npm run verify:qdro-route` failed on missing `out/qdro/index.html` for `/qdro/`.

## Proof
Commands run locally:
- `npm run lint`
- `npm run build`
- `npm run verify:qdro-route`
- `npm run verify:favicon`
- `npm run verify:shared-auth-links`
- `npm run verify:runtime`
- `git diff --check`

Local static preview proof with `npx --yes serve@14 out -l tcp://127.0.0.1:4173`:
- `/qdro` -> 200, contains `Generate your QDRO`
- `/qdro/` -> 200, contains `Generate your QDRO`
- `/products/qdro` -> 200, contains `Generate your QDRO`
- `/products/qdro/` -> 200, contains `Generate your QDRO`

Browser spot-check against local preview:
- `http://127.0.0.1:4173/qdro/` title `QDRO Generator — LexyAlgo`, H1 `Generate your QDRO. $100 per order.`, no 404 body, CTA href decodes through `atlas.lexyalgo.com/login` to `https://doc-v2.lexyalgo.com/interview?i=docassemble.LexyAlgoQDROV2:data/questions/qdro_v2_router.yml`.
- `http://127.0.0.1:4173/products/qdro/` same title/H1/no-404/CTA callback proof.

## Notes
- No production deploy in this PR. Merge/deploy should wait for Otto independent review plus headed desktop/mobile browser QA from Kanban card `t_9c22346c`.
